### PR TITLE
SEO Round 3: keyword-driven content + EMC framing across /car-accident/*

### DIFF
--- a/SEO_CHANGELOG.md
+++ b/SEO_CHANGELOG.md
@@ -127,6 +127,75 @@ Non-visual SEO improvements for car accident urgent care lead generation in Palm
 
 ---
 
+## Audit Round 3 — 2026-05-22 (Keyword-Driven Content Optimization)
+
+**Scope**: `/car-accident-injury-clinic` only — content-level keyword optimization layered on top of the schema/metadata foundation from rounds 1 & 2. First deliverable of the agency's "Special Project — PUC Landing Page & Car-Accident Pages" workstream (5/27 deadline). Sibling pages will follow on a weekly cadence.
+
+**Driver**: pre-edit Ahrefs analysis (2026-05-22) showed the URL ranked for 1 organic kw (vol 30, pos 10, 0 traffic) and the domain ranked for 12 kw total — zero car-accident-related. Schema/metadata work was complete but content-level kw targeting was never done. Full audit doc: `accounts/primary-urgent-care/seo/2026-05-22-car-accident-landing-page-audit.md`.
+
+### File Changes — `app/car-accident-injury-clinic/page.tsx`
+
+- **Metadata title**: "Car Accident Urgent Care Palm Beach | PIP Exam | PrimaryUC" → "Car Accident Doctor in Palm Beach County | PIP Exam | PrimaryUC" (leads with "car accident doctor" — 1,400 vol Tier 1 kw; rephrased OG + Twitter to match).
+- **Metadata description**: "Car accident urgent care in Palm Beach County. Same-day evaluation, PIP documentation, walk-in welcome…" → "Car accident doctor & urgent care clinic in Palm Beach County. Same-day PIP exam, onsite X-ray, walk-in welcome…" (adds "car accident doctor" + "car accident clinic").
+- **OG image alt**: rewritten to "Car accident doctor at PrimaryUC Palm Beach County car accident injury clinic with onsite X-ray".
+- **H1** (via `HeroWithForm` title prop): "Car Accident Injury Clinic in Palm Beach County" → "Car Accident Doctor & Urgent Care Clinic in Palm Beach County" (3 Tier 1 kw + geo, 60 chars).
+- **Hero subtitle**: rewritten to include "car accident doctors", "car accident injury clinic", "PIP documentation" naturally.
+- **NEW H2 section "When to See a Car Accident Doctor in Florida"**: inserted after `FourteenDayUrgencyBlock`. Captures Tier 2 question-form kw ("doctor to see after car accident" 150 vol KD 1; "should I see a doctor after a car accident" 150 vol KD 1; "what doctor to see after car accident" 90 vol KD 1; "after car accident doctor" 150 vol KD 0). Includes 4 in-prose internal links: `/blog/headache-after-car-accident`, `/blog/hip-pain-after-car-accident`, `/car-accident/urgent-care-vs-er`.
+- **Section title rename**: "Types of Car Accident Injuries We Treat" → "Car Accident Injuries Our Doctors Treat".
+- **Section title rename**: "Car Accident Urgent Care Locations" → "Find a Car Accident Clinic Near You — 4 Palm Beach Locations" (captures "car accident clinic near me" 400 vol KD 6; "car accident urgent care near me" 150 vol KD 4); added 60-word intro paragraph above the LinkCardGrid.
+- **AccidentSEOContent** prop body: rewritten from 130-word generic block to 220-word kw-tuned block. Includes Tier 1 kw (car accident doctor, car accident injury clinic, car accident clinic near me, car accident urgent care, car accident doctor near me) + all 4 city names + PIP/EMC framing.
+- **NEW H2 section "Doctor or Chiropractor After a Car Accident?"**: inserted before FAQ. Captures "doctor or chiropractor after car accident" (200 vol KD 0). Links to `/car-accident/documentation-pip`.
+- **FAQ overhaul**: replaced 5 default questions in `AccidentFAQ` (component defaults) with 7 explicit kw-aligned questions passed via new `faqs` prop. Single `accidentFaqs` const declared at top of page so the visible FAQ component and the JSON-LD `FAQPage` schema consume the same source — eliminates the schema/visible-content drift Round 2 had to fix. New section title: "Frequently Asked Questions About Car Accident Injury Care".
+- **`faqSchemaObj`**: rewritten to `accidentFaqs.map(...)` — derived from the const, can't drift from visible content.
+
+### Fact-Check Round (NEW process this round)
+
+Spawned `blog-fact-checker` subagent to adversarially review every factual claim in the new content before commit. Round 1 returned NEEDS_PATCHES with 6 specific patches:
+
+- **Patch 1 (Section 3 AccidentSEOContent)**: added one-sentence EMC clarification. Fla. Stat. § 627.736(1)(a)3-4 caps PIP medical benefits at $2,500 without an Emergency Medical Condition determination — only MD/DO/PA/APRN/dentist can certify EMC. Page didn't mention this; now does.
+- **Patch 2 (Section 5 Doctor-vs-Chiropractor)**: corrected the legal hook. Original framing implied chiropractors don't satisfy the 14-day rule — under § 627.736(1)(a)1, they explicitly DO. Rewrote to use the EMC certification authority as the accurate distinction (both MD and chiropractor satisfy 14-day initial services; only certain providers can certify EMC for the full $10,000 cap).
+- **Patch 3 (FAQ Q1)**: same EMC-correct framing applied.
+- **Patch 4 (FAQ Q4)**: same correction — "a chiropractor cannot [certify EMC], under Florida law" replaces the prior implication that chiropractors don't satisfy the 14-day rule.
+- **Patch 5 (FAQ Q5)**: separated 14-day-rule satisfaction from EMC certification authority.
+- **Patch 6 (FAQ Q7)**: softened the invented "45-60 minute median visit time" to "in a single visit on the day they walk in" — operational sign-off from Bilal/PUC required if the specific time is to be re-added.
+
+Round 2 fact-check on the patched draft: **PASS**, no new errors introduced. Reports at:
+- `accounts/primary-urgent-care/seo/car-accident-injury-clinic-seo-2026-05-22.factcheck.md` (round 1)
+- `accounts/primary-urgent-care/seo/car-accident-injury-clinic-seo-2026-05-22-round-2.factcheck.md` (round 2)
+
+### Build Result
+
+`npx tsc --noEmit` reports 6 errors in `app/car-accident-injury-clinic/page.tsx`, all pre-existing on `main`: `AccidentInfoSection` `type` prop uses `"primary"` / `"secondary"` but the component expects `"success" | "warning" | "info" | undefined`. Errors exist on main pre-edit (verified by stash + recheck). This branch introduces **0 new TypeScript errors**.
+
+### Operational Items — Need Bilal/PUC Sign-Off Before Merge
+
+These are claims about PUC's actual operations that the fact-checker flagged for confirmation:
+
+1. Four locations open and accepting walk-in accident patients today: Royal Palm Beach, Lake Worth, Palm Springs, Lantana
+2. All four locations actively prioritize accident-related visits in queue
+3. Onsite digital X-ray available at all four locations
+4. CT/MRI referrals with "STAT reads ≤ 3 hrs" (existing claim on page from earlier rounds — not introduced this round)
+5. PIP-compliant documentation routinely generated at the visit
+
+If any of these are not accurate today, the relevant sentences need to be softened or removed before merge.
+
+### Routes Benefited (this round)
+
+| Route | Changes |
+|-------|---------|
+| `/car-accident-injury-clinic` | Metadata title + description, H1, hero subtitle, 2 new H2 sections, 2 section title renames, AccidentSEOContent rewrite, 7-question FAQ replacing 5 defaults, FAQ schema derived from same const, EMC framing throughout |
+
+### Audit Round 4 (planned, weekly cadence)
+
+After 5/22 daily-engine stability is confirmed, roll the same playbook to siblings on weekly cadence:
+- Week 1 (after 5/27): `/car-accident/whiplash`
+- Week 2: `/car-accident/back-neck-pain`
+- Week 3: `/car-accident/documentation-pip`
+- Week 4: `/car-accident/urgent-care-vs-er`
+- Weeks 5-8: 4 `/car-accident/[city]` pages
+
+---
+
 ## SEO Verification Checklist (Post-Deploy)
 
 1. **Google Search Console**

--- a/SEO_CHANGELOG.md
+++ b/SEO_CHANGELOG.md
@@ -184,15 +184,35 @@ If any of these are not accurate today, the relevant sentences need to be soften
 | Route | Changes |
 |-------|---------|
 | `/car-accident-injury-clinic` | Metadata title + description, H1, hero subtitle, 2 new H2 sections, 2 section title renames, AccidentSEOContent rewrite, 7-question FAQ replacing 5 defaults, FAQ schema derived from same const, EMC framing throughout |
+| `/car-accident/whiplash` | Metadata title + description, H1 + hero subtitle, 3 new H2 sections ("Signs of Whiplash After a Car Accident", "When Whiplash Becomes Chronic Neck Pain", "Why See a Whiplash Injury Doctor and Not Just a Chiropractor"), rewritten "How to Treat Whiplash" section with Quebec Task Force reference, 7-question FAQ via `whiplashFaqs` const replacing 5 prior, FAQ schema derived from same const, EMC framing |
+| `/car-accident/back-neck-pain` | Metadata title + description, H1 + hero subtitle, NEW FAQ section (page previously had none) with 7 kw-aligned questions via `backNeckFaqs` const, FAQ schema added to graph, 2 new H2 sections ("Delayed Back Pain & Delayed Neck Pain After a Car Accident", "Upper Back, Middle Back & Lower Back Pain — What's the Difference?"), new "Why See a Medical Doctor for Back Pain After a Car Accident" section with EMC framing, consolidated duplicate spine-exam content |
+| `/car-accident/documentation-pip` | Metadata title + description (now leads with "Florida PIP 14-Day Rule + EMC"), H1 + hero subtitle, 2 new H2 sections ("What Is Florida PIP Insurance, and How Does the 14-Day Rule Work?", "Emergency Medical Condition (EMC) — The $10,000 vs $2,500 Question"), 7-question FAQ via `pipFaqs` const replacing 2 prior, FAQ schema derived from same const, EMC definition tracking Fla. Stat. § 395.002(8) statutory text |
+| `/car-accident/urgent-care-vs-er` | Metadata title + description, H1 + hero subtitle, 7-question FAQ via `ucerFaqs` const replacing 4 prior, FAQ schema derived from same const, cost/wait-time comparison section softened (removed unverifiable specific dollar/minute figures, replaced with comparative framing), EMC framing throughout |
+| `/car-accident/[city]` (4 cities: royal-palm-beach, lake-worth, palm-springs, lantana) | FAQ consolidated to single `cityAccidentFaqs` const consumed by both visible component AND JSON-LD schema (eliminating drift risk), 8-question FAQ replacing 7 prior with new Q7 (EMC + 14-day rule) and new Q8 ("Why see a medical doctor instead of a chiropractor"), Q6 weekend hours softened to defer to per-city location page (removed hardcoded hours that were wrong for any city with different schedules) |
 
-### Audit Round 4 (planned, weekly cadence)
+### Process Changes (NEW this round)
 
-After 5/22 daily-engine stability is confirmed, roll the same playbook to siblings on weekly cadence:
-- Week 1 (after 5/27): `/car-accident/whiplash`
-- Week 2: `/car-accident/back-neck-pain`
-- Week 3: `/car-accident/documentation-pip`
-- Week 4: `/car-accident/urgent-care-vs-er`
-- Weeks 5-8: 4 `/car-accident/[city]` pages
+- **Adversarial fact-check via dedicated subagent**: every page edit was reviewed by a separate `blog-fact-checker` subagent before commit, biased toward finding errors rather than confirming them. The agent reads the draft cold (no attachment to specific phrasings) and verifies every factual claim against primary sources (statute text, peer-reviewed literature, clinical practice guidelines, agency press releases).
+- **Catches from this round**:
+  - **Whiplash**: Original draft conflated "chronic neck pain" (≥3 months) with "late whiplash syndrome" (more commonly ≥6 months in published literature). 3 patches applied to separate the two definitions.
+  - **Documentation-PIP**: Original EMC definition I drafted ("serious impairment, dysfunction, or permanent damage") drifted from the actual statutory text. 2 patches applied to match Fla. Stat. § 395.002(8) ("serious jeopardy to patient health, serious impairment of bodily functions, or serious dysfunction of any bodily organ or part").
+  - **Hub** (Round 3 initial): Original framing implied chiropractors don't satisfy the 14-day PIP rule. They explicitly DO under § 627.736(1)(a)(1) — the legal distinction is who can certify EMC, not who satisfies initial services. 6 patches applied across body and FAQ to use the correct legal hook.
+- **Back-neck-pain, urgent-care-vs-er, [city]**: PASS on first review, no patches needed.
+- **Fact-check reports preserved** in the agency workspace at `accounts/primary-urgent-care/seo/*.factcheck.md`.
+
+### Operational Items — Need Bilal/PUC Sign-Off Before Merge
+
+Operational claims about PUC's clinic operations are flagged for confirmation. If any are not accurate today, the relevant sentences need to be softened or removed:
+
+1. Four locations open and accepting walk-in accident patients today: Royal Palm Beach, Lake Worth, Palm Springs, Lantana
+2. All four locations actively prioritize accident-related visits in queue
+3. Onsite digital X-ray available at all four locations
+4. CT/MRI referrals coordinated when indicated
+5. PIP-compliant documentation routinely generated at the visit
+6. EMC certification offered when clinically appropriate at all four locations
+7. Single same-day visit workup is the standard for car accident presentations
+8. Specialist referral workflow (orthopedic spine, neurology) for persistent radicular symptoms (whiplash + back-neck-pain pages)
+9. 6-week re-evaluation + MRI consideration workflow for whiplash (whiplash page)
 
 ---
 

--- a/app/car-accident-injury-clinic/page.tsx
+++ b/app/car-accident-injury-clinic/page.tsx
@@ -25,15 +25,56 @@ import SlidingDiv from "@/components/SlidingAnimation";
 
 const baseUrl = "https://primaryuc.com";
 
+// Single source of truth for the visible FAQ + JSON-LD FAQPage schema.
+// Audit Round 2 (Feb 2026) flagged schema/visible-content mismatch as the FAQ rich-results blocker;
+// keeping the array referenced by both the component and the schema prevents the issue from returning.
+const accidentFaqs = [
+  {
+    question: "Should I see a doctor after a car accident, even if I feel fine?",
+    answer:
+      "Yes. Adrenaline at the scene of a crash typically suppresses pain for several hours, and inflammation from soft-tissue injury builds over the following 24 to 72 hours. Many patients who walked away from their accident feeling fine wake up the next morning with neck pain, back pain, headache, or stiffness that wasn't there before. In Florida, getting an early medical evaluation also matters legally — Personal Injury Protection benefits require a qualifying medical visit within 14 days of the crash, and a medical doctor's exam is what can certify the emergency medical condition needed to access the full $10,000 PIP cap.",
+  },
+  {
+    question: "Should I go to urgent care or the ER after a car accident?",
+    answer:
+      "For most non-life-threatening symptoms — whiplash, neck pain, back pain, headache, bruising, soft-tissue injury — urgent care is the appropriate setting. We handle examination, on-site digital X-ray, and PIP documentation in a single visit. Go directly to the ER for severe chest pain, loss of consciousness, signs of internal bleeding, neurological deficits, or any symptom that suggests a life-threatening injury. See our urgent care vs ER guide for the full breakdown.",
+  },
+  {
+    question: "How do I find a car accident doctor in Palm Beach County?",
+    answer:
+      "PrimaryUC operates four car accident urgent care locations in Palm Beach County: Royal Palm Beach, Lake Worth, Palm Springs, and Lantana. All four locations are walk-in — no appointment needed — and prioritize accident-related visits so you can be seen, imaged, and documented in a single visit. Choose the location closest to your home, work, or the crash scene.",
+  },
+  {
+    question: "Doctor or chiropractor after a car accident — which should I see first?",
+    answer:
+      "See a medical doctor first. A car accident doctor at an urgent care can order on-site X-rays, refer for CT or MRI when indicated, manage acute pain medically, and generate the PIP documentation your insurance carrier requires. A medical doctor can also certify the emergency medical condition needed to access the full $10,000 PIP cap — a chiropractor cannot, under Florida law. Chiropractic care can be a valuable follow-up for soft-tissue and musculoskeletal complaints once more serious injuries have been ruled out by imaging.",
+  },
+  {
+    question: "Can I go to urgent care after a car accident in Florida?",
+    answer:
+      "Yes. Urgent care is an appropriate setting for the majority of car accident injuries, including whiplash, back and neck pain, soft-tissue injury, minor fractures, and post-accident headache. PrimaryUC's urgent care visits satisfy Florida's 14-day PIP rule for initial services, and our medical doctors can certify the emergency medical condition needed to access the full $10,000 PIP medical cap.",
+  },
+  {
+    question: "What documentation does PIP insurance require after a car accident?",
+    answer:
+      "Your PIP carrier will require an initial medical evaluation note within 14 days of the accident, detailing the mechanism of injury, exam findings, any imaging performed, diagnoses, treatment plan, and recommendations for follow-up. PrimaryUC generates this documentation as part of every car accident visit and can coordinate directly with your insurer or any attorney you retain. See our PIP documentation guide for the full requirements.",
+  },
+  {
+    question: "How quickly can I be seen for a car accident injury at PrimaryUC?",
+    answer:
+      "Same day. We accept walk-ins at all four Palm Beach County locations and prioritize accident-related visits. Most patients are checked in, examined, imaged where appropriate, and documented in a single visit on the day they walk in. No appointment is required.",
+  },
+];
+
 export const metadata: Metadata = {
-  title: "Car Accident Urgent Care Palm Beach | PIP Exam | PrimaryUC",
+  title: "Car Accident Doctor in Palm Beach County | PIP Exam | PrimaryUC",
   description:
-    "Car accident urgent care in Palm Beach County. Same-day evaluation, PIP documentation, walk-in welcome. Onsite X-ray, Florida 14-day rule compliant. 4 locations.",
+    "Car accident doctor & urgent care clinic in Palm Beach County. Same-day PIP exam, onsite X-ray, walk-in welcome. Florida 14-day rule compliant. 4 locations.",
   alternates: { canonical: `${baseUrl}/car-accident-injury-clinic` },
   openGraph: {
-    title: "Car Accident Urgent Care Palm Beach | PIP Exam | PrimaryUC",
+    title: "Car Accident Doctor in Palm Beach County | PIP Exam | PrimaryUC",
     description:
-      "Car accident urgent care in Palm Beach County. Same-day evaluation, PIP documentation, walk-in welcome. Onsite X-ray, Florida 14-day rule compliant. 4 locations.",
+      "Car accident doctor & urgent care clinic in Palm Beach County. Same-day PIP exam, onsite X-ray, walk-in welcome. Florida 14-day rule compliant. 4 locations.",
     url: `${baseUrl}/car-accident-injury-clinic`,
     siteName: "Primary & Urgent Care Centers",
     images: [
@@ -41,7 +82,7 @@ export const metadata: Metadata = {
         url: `${baseUrl}/websitelogo.png`,
         width: 1200,
         height: 630,
-        alt: "Car accident doctor examining patient with neck brace in Palm Beach County urgent care",
+        alt: "Car accident doctor at PrimaryUC Palm Beach County car accident injury clinic with onsite X-ray",
       },
     ],
     locale: 'en_US',
@@ -49,8 +90,8 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: "Car Accident Urgent Care Palm Beach | PIP Exam | PrimaryUC",
-    description: "Car accident urgent care in Palm Beach County. Same-day evaluation, PIP documentation, walk-in welcome. Onsite X-ray, Florida 14-day rule compliant.",
+    title: "Car Accident Doctor in Palm Beach County | PIP Exam | PrimaryUC",
+    description: "Car accident doctor & urgent care clinic in Palm Beach County. Same-day PIP exam, onsite X-ray, walk-in welcome. Florida 14-day rule compliant.",
     images: [`${baseUrl}/websitelogo.png`],
     site: '@primaryurgentcare',
   },
@@ -68,50 +109,18 @@ export default function Page() {
     url: pageUrl
   });
 
+  // FAQPage schema derived from the same accidentFaqs const that drives the visible <AccidentFAQ /> component.
+  // This guarantees schema/visible-content parity — the issue Audit Round 2 (Feb 2026) had to fix.
   const faqSchemaObj = {
     "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: "Should I see a doctor immediately after a car accident?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: "Yes, you should seek medical attention as soon as possible after a car accident, even if you don't feel injured. Some injuries, like whiplash or internal trauma, may not show symptoms immediately but can worsen without proper treatment. Early evaluation also helps with insurance documentation."
-        }
+    mainEntity: accidentFaqs.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: f.answer,
       },
-      {
-        "@type": "Question",
-        name: "What types of injuries do you treat after car accidents?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: "We treat a wide range of car accident injuries including whiplash, back and neck pain, soft tissue injuries, minor fractures, contusions, cuts and scrapes, headaches, and concussion symptoms. Our onsite X-ray and imaging capabilities help us diagnose and treat most urgent care-level injuries."
-        }
-      },
-      {
-        "@type": "Question",
-        name: "Do you accept insurance for car accident injuries?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: "Yes, we accept most major insurance plans including PIP (Personal Injury Protection) coverage, which is required in Florida. We also work with auto insurance companies and can provide documentation for your personal injury claim. Our team will help coordinate billing and insurance verification."
-        }
-      },
-      {
-        "@type": "Question",
-        name: "How quickly can I be seen for car accident injuries?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: "We offer same-day appointments and welcome walk-ins for car accident injuries. Our urgent care centers typically have wait times under 15 minutes, and we prioritize accident-related injuries to ensure you receive prompt medical attention and documentation."
-        }
-      },
-      {
-        "@type": "Question",
-        name: "What documentation will I receive for my insurance claim?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: "We provide comprehensive documentation including detailed medical reports, X-ray results, treatment plans, and visit summaries. This documentation is essential for your insurance claim and any potential legal proceedings. We can also coordinate with your attorney if needed."
-        }
-      }
-    ]
+    })),
   };
 
   const breadcrumb = buildBreadcrumb([
@@ -152,16 +161,16 @@ export default function Page() {
 
       {/* Hero Section */}
       <HeroWithForm
-        title="Car Accident Injury Clinic in Palm Beach County"
+        title="Car Accident Doctor & Urgent Care Clinic in Palm Beach County"
         subtitle={
           <p>
-            Just had a crash? Our car accident doctors provide same-day exams, onsite X-ray, and documentation most insurers and attorneys request.
+            Just had a crash? Our car accident doctors at PrimaryUC&apos;s Palm Beach County car accident injury clinic provide same-day exams, onsite X-ray, and PIP documentation that insurers and attorneys request.
           </p>
         }
         checklist={[
           "Seen today — walk-ins welcome",
           "Onsite X-ray; rapid MRI/CT referrals",
-          "Visit summary & documentation for insurers",
+          "Visit summary & PIP documentation for insurers",
         ]}
         banner={<ImmediateCareBanner />}
         form={<AccidentAppointmentForm title="Check Car Accident Exam Availability" noWrapper={true} showHeader={false} compact={true} />}
@@ -172,6 +181,31 @@ export default function Page() {
 
       {/* Why You Must Be Seen Within 14 Days */}
       <FourteenDayUrgencyBlock />
+
+      {/* When to See a Car Accident Doctor in Florida */}
+      <section className="py-16 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 xl:px-[60px]">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
+              When to See a Car Accident Doctor in Florida
+            </h2>
+            <div className="space-y-4 text-lg text-gray-700 leading-relaxed">
+              <p>
+                The most common question patients ask us after a Florida crash is simple: <strong>&quot;Do I really need to see a doctor if I feel fine?&quot;</strong> The clinical answer is yes, and the legal answer in Florida is unambiguous — if you want your PIP benefits, you must be evaluated within 14 days of the accident.
+              </p>
+              <p>
+                The reason a doctor&apos;s visit matters even when symptoms are minimal comes down to two physiological facts: adrenaline at the scene masks pain for hours after a crash, and inflammation from soft-tissue injury typically builds over the following 24 to 72 hours. Patients who felt fine in the moments after their accident often wake up the next morning with stiffness, headache, neck pain, or back pain that wasn&apos;t there before. Our walk-in <a className="text-[#2563eb] underline hover:text-[#1d4ed8]" href="/blog/headache-after-car-accident">headache evaluation after a car accident</a> and <a className="text-[#2563eb] underline hover:text-[#1d4ed8]" href="/blog/hip-pain-after-car-accident">hip pain after a car accident</a> guides walk through the most commonly delayed symptoms we see.
+              </p>
+              <p>
+                For most non-life-threatening post-accident symptoms — whiplash, neck pain, back pain, headache, soft-tissue injury, joint pain — <strong>urgent care is the appropriate setting</strong>. We handle the imaging, examination, and PIP-compliant documentation in a single visit. The exceptions that require an emergency room — severe chest pain, loss of consciousness, neurological deficit, signs of internal bleeding — are detailed in our <a className="text-[#2563eb] underline hover:text-[#1d4ed8]" href="/car-accident/urgent-care-vs-er">urgent care vs ER guide</a>.
+              </p>
+              <p>
+                If you&apos;re wondering what doctor to see after a car accident in Florida, the practical answer is: a medical doctor who can perform a physical exam, order on-site imaging, and generate the PIP documentation your insurance carrier and any attorney you retain will require. Walk in to any PrimaryUC location — no appointment needed.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
 
       {/* Florida's 14-Day PIP Rule Section */}
       <section className='grid lg:grid-cols-2 gap-8 sm:gap-12 lg:gap-14 h-full px-4 sm:px-6 lg:px-8 xl:px-[60px] py-8 sm:py-12 lg:py-16 xl:py-20'>
@@ -215,7 +249,7 @@ export default function Page() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 xl:px-[60px]">
           <div className="text-center mb-12">
             <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
-              Types of Car Accident Injuries We Treat
+              Car Accident Injuries Our Doctors Treat
             </h2>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
               Our experienced team evaluates and treats a wide range of injuries commonly seen after motor vehicle collisions
@@ -321,17 +355,17 @@ export default function Page() {
       <AttorneyFriendlySection />
 
       {/* SEO Content Section */}
-      <AccidentSEOContent 
-        content="After a car accident, immediate medical evaluation is crucial for both your health and your claim. Under Florida's PIP 14-day rule, you must see a doctor within 14 days of your accident to unlock up to $10,000 in PIP benefits. Our experienced urgent care team provides comprehensive car accident injury assessments, including whiplash treatment, back and neck pain evaluation, and soft tissue injury care. We offer same-day appointments, onsite digital X-rays, and complete documentation for insurance claims and personal injury cases. Located throughout Palm Beach County, our clinics are equipped to handle everything from minor cuts and bruises to suspected spinal injuries. Our board-certified providers understand Florida's PIP 14-day rule and the documentation insurers and attorneys expect, so your visit generates clear, organized records that support your recovery. We work closely with insurance companies, attorneys, and legal teams to ensure you receive the proper medical documentation needed for your case, including whiplash settlement documentation and PIP claim paperwork."
+      <AccidentSEOContent
+        content="After a car accident, immediate medical evaluation is crucial for both your health and your insurance claim. Florida's PIP 14-day rule requires you to be seen by a qualifying medical provider within 14 days of your crash to access Personal Injury Protection (PIP) benefits. The full $10,000 PIP medical cap is only available when a medical doctor, osteopathic physician, dentist, physician assistant, or advanced practice registered nurse determines you have an emergency medical condition; without that determination, PIP medical benefits are capped at $2,500. PrimaryUC operates four car accident injury clinics across Palm Beach County, with same-day evaluation, onsite digital X-ray, and rapid CT/MRI referrals when indicated. Our urgent care team handles the full range of car accident injuries — whiplash, back pain, neck pain, soft-tissue injury, minor fractures, and post-accident headache evaluation — and we generate the medical documentation that PIP insurers and personal injury attorneys require. If you're searching for a car accident clinic near me, a car accident urgent care, or a car accident doctor near me in Palm Beach County, walk in to any of our four locations: Royal Palm Beach, Lake Worth, Palm Springs, or Lantana. No appointment needed; we prioritize accident-related visits so you can be seen, imaged, and documented in a single visit."
       />
 
       {/* Location Cards - Made Bigger and More Prominent */}
       <section className="py-16 bg-white">
         <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8 xl:px-[60px]">
           <div className="text-center mb-12">
-            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Car Accident Urgent Care Locations</h2>
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">Find a Car Accident Clinic Near You — 4 Palm Beach Locations</h2>
             <p className="text-lg text-gray-600 max-w-3xl mx-auto">
-              Get same-day car accident injury evaluation at any of our convenient Palm Beach County locations
+              Searching for a car accident clinic near me in Palm Beach County? PrimaryUC operates four car accident urgent care locations, each open daily for walk-in evaluation, same-day PIP documentation, and onsite digital X-ray. Find the location closest to your home, work, or the scene of your accident:
             </p>
           </div>
           <LinkCardGrid
@@ -389,8 +423,39 @@ export default function Page() {
         className="bg-white"
       />
 
+      {/* Doctor or Chiropractor After a Car Accident? */}
+      <section className="py-16 bg-[#FAFAFA]">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 xl:px-[60px]">
+          <div className="max-w-4xl mx-auto">
+            <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-6">
+              Doctor or Chiropractor After a Car Accident?
+            </h2>
+            <div className="space-y-4 text-lg text-gray-700 leading-relaxed">
+              <p>
+                Another question that comes up almost daily at our car accident injury clinic: <strong>after a crash, should I see a medical doctor or a chiropractor first?</strong>
+              </p>
+              <p>
+                The short answer: <strong>see a medical doctor first</strong>, and let the exam findings and imaging guide whether chiropractic care belongs in your recovery plan.
+              </p>
+              <p>
+                There are practical reasons this order matters. A car accident doctor at an urgent care can do things a chiropractor typically cannot: order and read on-site digital X-rays to rule out fracture, refer for CT or MRI imaging when soft-tissue injury or possible head injury is suspected, manage acute pain medically, and generate the kind of evaluation note your PIP carrier and any personal injury attorney will require. Both medical doctors and chiropractors can satisfy Florida&apos;s 14-day PIP rule for initial services, but only a medical doctor, osteopathic physician, dentist, physician assistant, or advanced practice registered nurse can certify the emergency medical condition needed to access the full $10,000 PIP benefit. Without that certification, PIP medical benefits are capped at $2,500 — which is the practical reason most patients are better served starting with a medical evaluation. See our <a className="text-[#2563eb] underline hover:text-[#1d4ed8]" href="/car-accident/documentation-pip">PIP documentation guide</a> for what specifically must be in the record.
+              </p>
+              <p>
+                Chiropractic care can be a valuable follow-up for soft-tissue injury, post-whiplash neck and back stiffness, and certain musculoskeletal complaints once a fracture or more serious injury has been ruled out. Many of our patients combine an initial urgent care visit (medical evaluation, imaging, PIP documentation) with later chiropractic care for ongoing soft-tissue treatment. The order — medical first, chiropractic as appropriate — protects both your health and your insurance claim.
+              </p>
+              <p>
+                If you&apos;re unsure where to start, walk in to a PrimaryUC car accident urgent care for the initial medical evaluation. We&apos;ll examine you, image where indicated, document the visit for your PIP claim, and discuss whether chiropractic follow-up makes sense for your specific injuries.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* FAQ Section */}
-      <AccidentFAQ />
+      <AccidentFAQ
+        title="Frequently Asked Questions About Car Accident Injury Care"
+        faqs={accidentFaqs}
+      />
 
       {/* Internal Links Section */}
       <AccidentInternalLinks />

--- a/app/car-accident/[city]/page.tsx
+++ b/app/car-accident/[city]/page.tsx
@@ -172,66 +172,53 @@ export default async function Page({ params }: { params: Promise<Params> }) {
     hasMap: c.gmbUrl
   };
 
+  // Single source of truth for visible <AccidentFAQ /> + JSON-LD FAQPage schema.
+  // Same array referenced below in the schema graph AND by the AccidentFAQ component near the bottom of the page.
+  const cityAccidentFaqs = [
+    {
+      question: `How quickly can I be seen for car accident injuries in ${cityName}?`,
+      answer: `We offer same-day appointments and welcome walk-ins at our ${cityName} location. Auto-injury visits are prioritized when possible so you can receive prompt medical evaluation and documentation. Getting evaluated quickly can help document symptoms, exam findings, and treatment recommendations within Florida's 14-day PIP window.`,
+    },
+    {
+      question: "What types of car accident injuries do you treat?",
+      answer: `We treat whiplash, back and neck pain, joint injuries, soft-tissue strains, minor fractures, contusions, cuts and scrapes, headaches, and concussion-like symptoms. Our ${cityName} location has onsite X-ray capabilities and can arrange MRI or CT referrals when needed. We provide comprehensive evaluation and treatment for most urgent care-level car accident injuries with same-day documentation.`,
+    },
+    {
+      question: "Do you provide documentation for insurance claims?",
+      answer:
+        "Yes. Every visit generates a detailed summary that includes exam findings, diagnoses, imaging results when performed, and recommended treatment. These records are designed for PIP and insurance documentation and can be shared with your insurance provider if needed.",
+    },
+    {
+      question: "Do you accept PIP and auto insurance?",
+      answer:
+        "We accept most major insurance plans, including PIP coverage and many auto insurance plans. Our team verifies coverage and handles claim-related paperwork whenever possible. We work directly with insurance companies to ensure proper processing of your claim and can help coordinate benefits and billing.",
+    },
+    {
+      question: "What should I bring to my exam?",
+      answer:
+        "Bring a photo ID, your insurance card, and any accident-related paperwork such as the claim number or police report, if available. If you have prior medical records related to this accident, bring those as well. We'll handle all the paperwork and documentation needed for your case.",
+    },
+    {
+      question: `Is Primary UC open on weekends for car accident walk-ins in ${cityName}?`,
+      answer: `Yes. Our ${cityName} location accepts walk-ins for car accident injuries during regular hours, including weekend hours. No appointment is required, but calling ahead helps us prepare your visit and minimize wait time. Call us at ${c.phoneDisplay} or check the location page for current hours.`,
+    },
+    {
+      question: "What is Florida's 14-day PIP rule, and why does it matter?",
+      answer: `Florida's PIP 14-day rule requires you to receive your initial medical visit within 14 days of the accident to access your Personal Injury Protection benefits. The clock counts from the crash date, not the day your symptoms started. The same statute also requires an Emergency Medical Condition (EMC) certification by a qualifying provider — MD, DO, PA, APRN, or dentist — to unlock the full $10,000 PIP medical cap. Without an EMC determination, PIP medical benefits cap at $2,500. Our ${cityName} car accident doctors meet both requirements in a single same-day visit. Call ${c.phoneDisplay} or walk in.`,
+    },
+    {
+      question: `Why see a medical doctor for car accident injuries in ${cityName} instead of a chiropractor?`,
+      answer: `Both medical doctors and chiropractors can satisfy Florida's 14-day PIP rule for initial services. But only a medical doctor, osteopathic physician, dentist, physician assistant, or advanced practice registered nurse can certify the Emergency Medical Condition needed to access the full $10,000 PIP medical benefit — chiropractors cannot, under Florida law. A medical doctor at our ${cityName} location can also order and read on-site X-ray, refer for MRI when soft-tissue or nerve injury is suspected, and screen for serious conditions a chiropractic visit cannot detect. Chiropractic care can be a valuable follow-up once those serious causes have been ruled out.`,
+    },
+  ];
+
   const faqSchemaObj = {
     "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: `How quickly can I be seen for car accident injuries in ${c.name}?`,
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: `We offer same-day appointments and welcome walk-ins at our ${c.name} location. Auto-injury visits are prioritized when possible so you can receive prompt medical evaluation and documentation. Getting evaluated quickly can help document symptoms, exam findings, and treatment recommendations within Florida's 14-day PIP window.`
-        }
-      },
-      {
-        "@type": "Question",
-        name: "What types of car accident injuries do you treat?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: `We treat whiplash, back and neck pain, joint injuries, soft-tissue strains, minor fractures, contusions, cuts and scrapes, headaches, and concussion-like symptoms. Our ${c.name} location has onsite X-ray capabilities and can arrange MRI or CT referrals when needed. We provide comprehensive evaluation and treatment for most urgent care-level car accident injuries with same-day documentation.`
-        }
-      },
-      {
-        "@type": "Question",
-        name: "Do you provide documentation for insurance claims?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: "Yes. Every visit generates a detailed summary that includes exam findings, diagnoses, imaging results when performed, and recommended treatment. These records are designed for PIP and insurance documentation and can be shared with your insurance provider if needed."
-        }
-      },
-      {
-        "@type": "Question",
-        name: "Do you accept PIP and auto insurance?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: "We accept most major insurance plans, including PIP coverage and many auto insurance plans. Our team verifies coverage and handles claim-related paperwork whenever possible. We work directly with insurance companies to ensure proper processing of your claim and can help coordinate benefits and billing."
-        }
-      },
-      {
-        "@type": "Question",
-        name: "What should I bring to my exam?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: "Bring a photo ID, your insurance card, and any accident-related paperwork such as the claim number or police report, if available. If you have prior medical records related to this accident, bring those as well. We'll handle all the paperwork and documentation needed for your case."
-        }
-      },
-      {
-        "@type": "Question",
-        name: `Is Primary UC open on weekends for car accident walk-ins in ${cityName}?`,
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: `Yes. Our ${cityName} location is open Monday–Friday 9am–6pm and Saturday 9am–4pm, including weekends. Walk-ins for car accident injuries are welcome any day. No appointment is required, but calling ahead helps us prepare your visit and minimize wait time. Call us at ${c.phoneDisplay}.`
-        }
-      },
-      {
-        "@type": "Question",
-        name: "What is Florida's 14-day rule and why does it matter for my accident claim?",
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: `Florida's 14-day PIP rule may affect your ability to use PIP benefits after an accident. Getting evaluated quickly can help document your symptoms, exam findings, and treatment recommendations. Our ${cityName} clinic offers same-day accident exams when available. Call ${c.phoneDisplay} or walk in.`
-        }
-      }
-    ]
+    mainEntity: cityAccidentFaqs.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
   };
 
   const webPageSchema = {
@@ -591,39 +578,7 @@ export default async function Page({ params }: { params: Promise<Params> }) {
       {/* FAQ Section */}
       <AccidentFAQ
         title={`Frequently Asked Questions About Car Accident Injuries in ${cityName}`}
-        faqs={[
-          {
-            question: `How quickly can I be seen for car accident injuries in ${cityName}?`,
-            answer: `We offer same-day appointments and welcome walk-ins at our ${cityName} location. Auto-injury visits are prioritized when possible so you can receive prompt medical evaluation and documentation. Getting evaluated quickly can help document symptoms, exam findings, and treatment recommendations within Florida's 14-day PIP window.`
-          },
-          {
-            question: "What types of car accident injuries do you treat?",
-            answer: `We treat whiplash, back and neck pain, joint injuries, soft-tissue strains, minor fractures, contusions, cuts and scrapes, headaches, and concussion-like symptoms. Our ${cityName} location has onsite X-ray capabilities and can arrange MRI or CT referrals when needed. We provide comprehensive evaluation and treatment for most urgent care-level car accident injuries with same-day documentation.`
-          },
-          {
-            question: "Do you provide documentation for insurance claims?",
-            answer:
-              "Yes. Every visit generates a detailed summary that includes exam findings, diagnoses, imaging results when performed, and recommended treatment. These records are designed for PIP and insurance documentation and can be shared with your insurance provider if needed."
-          },
-          {
-            question: "Do you accept PIP and auto insurance?",
-            answer:
-              "We accept most major insurance plans, including PIP coverage and many auto insurance plans. Our team verifies coverage and handles claim-related paperwork whenever possible. We work directly with insurance companies to ensure proper processing of your claim and can help coordinate benefits and billing."
-          },
-          {
-            question: "What should I bring to my exam?",
-            answer:
-              "Bring a photo ID, your insurance card, and any accident-related paperwork such as the claim number or police report, if available. If you have prior medical records related to this accident, bring those as well. We'll handle all the paperwork and documentation needed for your case."
-          },
-          {
-            question: `Is Primary UC open on weekends for car accident walk-ins in ${cityName}?`,
-            answer: `Yes. Our ${cityName} location is open Monday–Friday 9am–6pm and Saturday 9am–4pm, including weekends. Walk-ins for car accident injuries are welcome any day. No appointment is required, but calling ahead helps us prepare your visit and minimize wait time. Call us at ${c.phoneDisplay}.`
-          },
-          {
-            question: "What is Florida's 14-day rule and why does it matter for my accident claim?",
-            answer: `Florida's 14-day PIP rule may affect your ability to use PIP benefits after an accident. Getting evaluated quickly can help document your symptoms, exam findings, and treatment recommendations. Our ${cityName} clinic offers same-day accident exams when available. Call us at ${c.phoneDisplay} or walk in.`
-          }
-        ]}
+        faqs={cityAccidentFaqs}
       />
 
       {/* Location Cross-Link — connects car accident page to corresponding clinic location */}

--- a/app/car-accident/back-neck-pain/page.tsx
+++ b/app/car-accident/back-neck-pain/page.tsx
@@ -9,19 +9,59 @@ import TrustBadges from "@/components/accident/TrustBadges";
 import RedFlagChecklist from "@/components/accident/RedFlagChecklist";
 import AccidentInternalLinks from "@/components/accident/AccidentInternalLinks";
 import AccidentInfoSection from "@/components/accident/AccidentInfoSection";
+import AccidentFAQ from "@/components/accident/AccidentFAQ";
 import { toJsonLd, buildBreadcrumb, buildServiceSchema, buildGraphSchema } from "@/lib/seo";
 
 const baseUrl = "https://primaryuc.com";
 
+// Single source of truth for visible FAQ + JSON-LD FAQPage schema.
+const backNeckFaqs = [
+  {
+    question: "When should I see a doctor for back pain after a car accident?",
+    answer:
+      "If you have any back pain after a car accident in Florida, you should be evaluated within 14 days of the crash to preserve your PIP benefits. The most urgent presentations — severe pain, loss of bladder or bowel control, leg weakness, or pain that radiates down a leg — require ER care immediately. Moderate back or neck pain with normal neurological function is appropriate for same-day urgent care evaluation. Even mild soreness is worth a visit because delayed-onset back pain after a car accident is extremely common, and Florida's PIP clock runs from the crash date, not from the day your symptoms started.",
+  },
+  {
+    question: "Why does back pain show up days after a car accident?",
+    answer:
+      "Delayed back pain after a car accident is the rule, not the exception. Adrenaline at the scene of a crash typically suppresses pain for several hours, and inflammation from injured muscles, ligaments, and discs builds gradually over the following 24 to 72 hours. Many patients with significant lumbar or cervical injuries first notice meaningful pain the morning after the accident — or even two or three days later. Delayed onset does not mean the injury is minor; it reflects normal post-trauma physiology.",
+  },
+  {
+    question: "What kinds of back and neck injuries happen in car accidents?",
+    answer:
+      "Most common: muscle strains and ligament sprains from sudden impact forces. Also common: facet joint irritation (the small joints between vertebrae), herniated or bulging discs in the neck (cervical) or lower back (lumbar), and nerve-root irritation that causes shooting pain, tingling, or weakness in an arm or leg. Less common but more serious: compression fractures (more frequent in older patients and higher-energy crashes), spinal cord injury, and instability. Imaging is the only reliable way to distinguish soft-tissue injuries from structural injuries.",
+  },
+  {
+    question: "Do I need an MRI or just an X-ray for back pain after a car accident?",
+    answer:
+      "X-ray is the first-line imaging study because it rules out fracture and gross instability and can be done on-site in minutes. MRI is the better study for soft-tissue and disc injury, nerve compression, or ligament damage, and is typically ordered when symptoms include numbness, weakness, radicular pain (pain radiating down an arm or leg), or when symptoms aren't improving with conservative care. We do digital X-ray on-site at PrimaryUC; MRI is coordinated via referral when indicated.",
+  },
+  {
+    question: "Why see a medical doctor for back pain instead of going straight to a chiropractor?",
+    answer:
+      "Both medical doctors and chiropractors can satisfy Florida's 14-day PIP rule for initial services. The legal difference is that only a medical doctor, osteopathic physician, dentist, physician assistant, or advanced practice registered nurse can certify the emergency medical condition needed to access the full $10,000 PIP medical benefit — without that certification, PIP benefits cap at $2,500. The clinical difference is that a medical doctor can order and read X-ray on-site, refer for MRI, and perform a full neurological exam to rule out the dangerous causes of back pain (disc herniation with nerve compression, cauda equina, fracture). Chiropractic care can be a valuable follow-up for soft-tissue rehabilitation once those serious causes have been ruled out.",
+  },
+  {
+    question: "How long does back pain last after a car accident?",
+    answer:
+      "Mild muscle strains and soft-tissue injuries typically improve within 2 to 6 weeks with appropriate care. Moderate disc-related or facet-joint injuries can take several weeks to months. A subset of patients develop chronic back pain — defined as symptoms persisting past about three months — particularly if the initial injury was severe, evaluation was delayed, or there's a pre-existing spinal condition. Early evaluation, accurate diagnosis, and a documented treatment plan all reduce the risk of chronification.",
+  },
+  {
+    question: "Can back pain after a car accident come back years later?",
+    answer:
+      "Yes. Patients sometimes return with back pain 1 to 2 years after a car accident, particularly when the initial injury was undertreated or when imaging missed a disc or facet injury. Post-traumatic degenerative changes can also develop on top of the original injury. A new evaluation is appropriate any time post-accident back pain recurs — and your original PIP visit records make it easier to demonstrate the link to the original collision if needed for a separate claim.",
+  },
+];
+
 export const metadata: Metadata = {
-  title: "Back & Neck Pain After Car Accident | PIP Exam | PrimaryUC",
+  title: "Back Pain After a Car Accident | Same-Day Exam, PIP | PrimaryUC",
   description:
-    "Back & neck pain after car accident at urgent care in Palm Beach County. Same-day spinal exam, X-ray, PIP documentation. Florida 14-day rule. Walk-ins welcome.",
+    "Back pain or neck pain after a car accident in Palm Beach County. Same-day spinal exam, onsite X-ray, PIP documentation. Florida 14-day rule. Walk-ins welcome.",
   alternates: { canonical: `${baseUrl}/car-accident/back-neck-pain` },
   openGraph: {
-    title: "Back & Neck Pain After Car Accident | PIP Exam | PrimaryUC",
+    title: "Back Pain After a Car Accident | Same-Day Exam, PIP | PrimaryUC",
     description:
-      "Back & neck pain after car accident at urgent care in Palm Beach County. Same-day spinal exam, X-ray, PIP documentation. Florida 14-day rule. Walk-ins welcome.",
+      "Back pain or neck pain after a car accident in Palm Beach County. Same-day spinal exam, onsite X-ray, PIP documentation. Florida 14-day rule. Walk-ins welcome.",
     url: `${baseUrl}/car-accident/back-neck-pain`,
     type: 'article',
     siteName: "Primary & Urgent Care Centers",
@@ -30,15 +70,15 @@ export const metadata: Metadata = {
         url: `${baseUrl}/back-pain-hero.png`,
         width: 1200,
         height: 630,
-        alt: "Back and neck pain spinal exam after car accident in Palm Beach County urgent care",
+        alt: "Doctor performing spinal exam for back pain and neck pain after car accident in Palm Beach County urgent care",
       },
     ],
     locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
-    title: "Back & Neck Pain After Car Accident | PIP Exam | PrimaryUC",
-    description: "Back & neck pain after a car accident? Same-day spinal exam, X-ray & PIP documentation at Palm Beach County urgent care. Walk-ins welcome.",
+    title: "Back Pain After a Car Accident | Same-Day Exam, PIP | PrimaryUC",
+    description: "Back pain after a car accident? Same-day spinal exam, X-ray & PIP documentation at Palm Beach County urgent care. Walk-ins welcome.",
     images: [`${baseUrl}/back-pain-hero.png`],
     site: '@primaryurgentcare',
   },
@@ -101,11 +141,22 @@ export default function Page() {
     }
   };
 
+  // FAQPage schema derived from the backNeckFaqs const — schema cannot drift from visible content.
+  const faqObj = {
+    "@type": "FAQPage",
+    mainEntity: backNeckFaqs.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
+  };
+
   const graphSchema = buildGraphSchema([
     breadcrumb,
     webPageSchema,
     spinalConditionSchema,
     serviceSchema,
+    faqObj,
   ]);
 
   return (
@@ -117,10 +168,10 @@ export default function Page() {
 
       {/* Hero Section */}
       <HeroWithForm
-        title="Back & Neck Pain After a Car Crash"
+        title="Back Pain & Neck Pain After a Car Accident — Palm Beach County"
         subtitle={
           <p>
-            Back or neck pain after a crash should be taken seriously. Our car-accident doctors evaluate your spine, nerves, and muscles and document everything for PIP and insurance.
+            Back pain or neck pain after a car accident — even delayed-onset pain that starts days later — needs evaluation. Our car accident doctors examine your spine, screen for nerve involvement, X-ray on-site, and generate PIP-compliant documentation in a single same-day visit.
           </p>
         }
         checklist={[
@@ -140,22 +191,36 @@ export default function Page() {
         <div className="max-w-4xl mx-auto">
 
         <section className="mb-8">
-          <h2 className="text-2xl font-bold text-black mb-3">How We Evaluate Back & Neck Pain After a Crash</h2>
+          <h2 className="text-2xl font-bold text-black mb-3">Delayed Back Pain & Delayed Neck Pain After a Car Accident</h2>
           <p className="text-base md:text-lg text-gray-700 mb-4">
-            Our comprehensive spinal evaluation includes multiple components to assess your injury:
+            Delayed-onset back pain after a car accident is the rule, not the exception. Two physiological factors explain it: adrenaline at the scene typically suppresses pain for several hours, and inflammation from injured muscles, ligaments, and discs builds gradually over the following 24 to 72 hours. Many patients with significant lumbar or cervical injuries first notice meaningful pain the morning after the accident — sometimes two or three days later.
+          </p>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            This matters in two ways. Clinically, late-onset pain is not a sign of a minor injury — it&apos;s the normal post-trauma timeline. Legally, Florida&apos;s 14-day PIP rule counts from the date of the accident, not the date your symptoms started. If your back pain shows up on day five, you still have only nine days left to be seen and preserve your PIP benefits.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-bold text-black mb-3">Upper Back, Middle Back & Lower Back Pain — What&apos;s the Difference?</h2>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            Where the pain is located helps narrow what&apos;s going on, what imaging makes sense, and what the recovery looks like:
           </p>
           <div className="space-y-4 mb-6">
             <div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-2">Spine Exam</h3>
-              <p className="text-gray-700">We check for tenderness, muscle spasm, and joint restriction throughout your spine. This helps identify the specific areas affected by the collision.</p>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Lower Back Pain After a Car Accident</h3>
+              <p className="text-gray-700">The most common location for post-accident back pain. Typically involves lumbar muscle strain, facet joint irritation, or — in higher-energy crashes — disc herniation or compression fracture. Pain that radiates down a leg (sciatica), is accompanied by leg weakness or numbness, or involves loss of bladder or bowel control is a red-flag presentation requiring immediate evaluation.</p>
             </div>
             <div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-2">Neurologic Exam</h3>
-              <p className="text-gray-700">Strength, sensation, and reflex testing helps identify nerve involvement. This is critical for determining if you need immediate emergency care or if urgent care is appropriate.</p>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Upper Back Pain After a Car Accident</h3>
+              <p className="text-gray-700">Less common than lower back but frequently seen after side-impact crashes, seatbelt loading, or airbag deployment. Often involves thoracic muscle strain, rib or sternocostal injury, and thoracic-spine facet irritation. Upper back pain combined with chest pain or shortness of breath should be evaluated promptly to rule out rib fracture or intrathoracic injury.</p>
             </div>
             <div>
-              <h3 className="text-xl font-semibold text-gray-900 mb-2">Imaging Decisions</h3>
-              <p className="text-gray-700">Based on your exam findings, we determine when X-ray, MRI, or CT imaging is needed. We have onsite X-ray capabilities and can arrange advanced imaging referrals when indicated.</p>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Middle Back Pain After a Car Accident</h3>
+              <p className="text-gray-700">Pain between the shoulder blades or in the mid-thoracic region, typically from seatbelt loading or postural strain at the moment of impact. Usually responds well to anti-inflammatory medications, postural correction, and graduated activity.</p>
+            </div>
+            <div>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Neck Pain After a Car Accident</h3>
+              <p className="text-gray-700">Most often involves cervical strain or whiplash from rear-end and side-impact crashes. Symptoms can include reduced range of motion, headaches at the base of the skull, dizziness, and pain or numbness radiating down an arm. See our <Link className="text-[#2563eb] underline hover:text-[#1d4ed8]" href="/car-accident/whiplash">whiplash treatment guide</Link> for a deeper breakdown.</p>
             </div>
           </div>
         </section>
@@ -233,12 +298,30 @@ export default function Page() {
           </ul>
         </section>
 
-        <RelatedTopics 
+        <section className="mb-8">
+          <h2 className="text-2xl font-bold text-black mb-3">Why See a Medical Doctor for Back Pain After a Car Accident</h2>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            Both medical doctors and chiropractors can satisfy <strong>Florida&apos;s 14-day PIP rule</strong> for initial services after a car accident. But only a medical doctor, osteopathic physician, dentist, physician assistant, or advanced practice registered nurse can certify the emergency medical condition needed to access the full $10,000 PIP medical benefit — without that certification, PIP medical benefits are capped at $2,500.
+          </p>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            For back and neck pain specifically, the clinical reason to start with a medical doctor is also strong: a medical workup can order and read X-ray on-site, refer for MRI when nerve involvement or disc injury is suspected, and perform a full neurological exam to screen for the dangerous causes of post-accident back pain (significant disc herniation with nerve compression, cauda equina syndrome, occult fracture). Chiropractic care can be a valuable follow-up for soft-tissue rehabilitation once those serious causes have been ruled out.
+          </p>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            See our <Link className="text-[#2563eb] underline hover:text-[#1d4ed8]" href="/car-accident/documentation-pip">PIP documentation guide</Link> for what specifically must be in the record.
+          </p>
+        </section>
+
+        <RelatedTopics
           topics={[
             { title: "Whiplash", href: "/car-accident/whiplash" },
             { title: "PIP & Documentation", href: "/car-accident/documentation-pip" },
             { title: "Car Accident Urgent Care", href: "/car-accident-injury-clinic" }
           ]}
+        />
+
+        <AccidentFAQ
+          title="Back & Neck Pain After a Car Accident — Frequently Asked Questions"
+          faqs={backNeckFaqs}
         />
 
         {/* Internal Links Section */}

--- a/app/car-accident/documentation-pip/page.tsx
+++ b/app/car-accident/documentation-pip/page.tsx
@@ -13,15 +13,54 @@ import { toJsonLd, buildBreadcrumb, buildServiceSchema, buildGraphSchema } from 
 
 const baseUrl = "https://primaryuc.com";
 
+// Single source of truth for visible FAQ + JSON-LD FAQPage schema.
+const pipFaqs = [
+  {
+    question: "What is PIP insurance in Florida?",
+    answer:
+      "PIP — Personal Injury Protection — is the mandatory no-fault auto insurance coverage required of all Florida drivers under Fla. Stat. § 627.736. It pays for your medical evaluation and treatment after a car accident regardless of who was at fault. Florida PIP provides up to $10,000 in medical and disability benefits per accident — but only if you receive your initial medical evaluation within 14 days of the crash and a qualifying provider certifies an emergency medical condition. Without that certification, PIP medical benefits cap at $2,500.",
+  },
+  {
+    question: "What is the Florida PIP 14-day rule?",
+    answer:
+      "The Florida PIP 14-day rule requires you to receive initial medical services within 14 days of your motor vehicle accident to be eligible for PIP medical benefits. The 14 days are counted from the date of the accident — not from the day your symptoms appeared. If you wait beyond day 14, your PIP carrier can deny the medical portion of your claim, leaving you responsible for the medical costs out of pocket. The same rule applies whether your injuries were serious, mild, or initially asymptomatic.",
+  },
+  {
+    question: "What is an Emergency Medical Condition (EMC) and why does it matter?",
+    answer:
+      "An Emergency Medical Condition (EMC) is a clinical determination — drawn from Fla. Stat. § 395.002(8) and applied through Florida's PIP statute — that your injuries manifest as acute symptoms severe enough that, without immediate medical attention, they could reasonably result in serious jeopardy to your health, serious impairment of bodily functions, or serious dysfunction of any bodily organ or part. Under Florida PIP statute § 627.736(1)(a), only a medical doctor (MD), osteopathic physician (DO), dentist, physician assistant (PA), or advanced practice registered nurse (APRN) can certify an EMC. The certification matters financially: with an EMC, your PIP medical benefit is $10,000; without one, it caps at $2,500. Chiropractors and physical therapists cannot certify an EMC under Florida law.",
+  },
+  {
+    question: "What does PIP insurance cover in Florida?",
+    answer:
+      "Florida PIP covers 80% of reasonable and necessary medical expenses (up to the PIP limit), 60% of lost wages, and 100% of replacement services (household help, childcare you'd otherwise do). It also provides a $5,000 death benefit. Covered medical services include emergency room visits, urgent care, hospital stays, surgery, X-ray and other imaging, rehabilitation, and prescription medications — provided they're documented as reasonable and medically necessary. PIP does not cover pain and suffering, vehicle damage, or third-party liability — those fall under other coverages.",
+  },
+  {
+    question: "How much is PIP insurance in Florida?",
+    answer:
+      "PIP premiums vary by driver, vehicle, location, and carrier, but the statutory minimum coverage every Florida driver must carry is $10,000 in PIP medical/disability and $10,000 in PDL (Property Damage Liability). Many drivers choose higher PIP limits if available from their carrier. We don't sell insurance — for current PIP premium quotes, contact a Florida-licensed insurance agent. Our role is on the medical side: we provide the same-day exam, imaging, and PIP-compliant documentation your carrier requires once a claim is opened.",
+  },
+  {
+    question: "Do I need an attorney before I come in for a PIP exam?",
+    answer:
+      "No. You can come in for an exam and documentation whether or not you have an attorney. Many patients see us first, get the medical workup and PIP documentation in order, and then decide whether to retain a personal injury attorney later. If you decide to work with one, we can share your records once you sign a release. Florida PIP benefits are available to you regardless of whether you have legal representation.",
+  },
+  {
+    question: "Can PrimaryUC update my documentation over time?",
+    answer:
+      "Yes. Follow-up visits generate updated records that show how your symptoms and function change over weeks or months. These ongoing records can be important for both medical recovery tracking and any insurance or legal claims. If your PIP carrier or attorney needs additional documentation, we can typically generate a supplemental note from your visit records.",
+  },
+];
+
 export const metadata: Metadata = {
-  title: "Car Accident PIP Exam & Documentation | PrimaryUC",
+  title: "Florida PIP 14-Day Rule + EMC | Car Accident Exam | PrimaryUC",
   description:
-    "Car accident PIP exam and documentation at urgent care in Palm Beach County. Same-day medical records, visit summaries, insurance paperwork. Florida 14-day rule compliant.",
+    "Florida PIP 14-day rule explained. Same-day car accident exam, emergency medical condition (EMC) certification, and PIP documentation in Palm Beach County. $10,000 cap protected.",
   alternates: { canonical: `${baseUrl}/car-accident/documentation-pip` },
   openGraph: {
-    title: "Car Accident PIP Exam & Documentation | PrimaryUC",
+    title: "Florida PIP 14-Day Rule + EMC | Car Accident Exam | PrimaryUC",
     description:
-      "Car accident PIP exam and documentation at urgent care in Palm Beach County. Same-day medical records, visit summaries, insurance paperwork. Florida 14-day rule compliant.",
+      "Florida PIP 14-day rule explained. Same-day car accident exam, emergency medical condition (EMC) certification, and PIP documentation in Palm Beach County. $10,000 cap protected.",
     url: `${baseUrl}/car-accident/documentation-pip`,
     type: 'article',
     siteName: "Primary & Urgent Care Centers",
@@ -30,15 +69,15 @@ export const metadata: Metadata = {
         url: `${baseUrl}/man-on-phone-next-to-open-hood.jpg`,
         width: 1200,
         height: 630,
-        alt: "Car accident PIP documentation and medical exam paperwork in Palm Beach County",
+        alt: "Florida PIP 14-day rule documentation and emergency medical condition exam after car accident in Palm Beach County",
       },
     ],
     locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
-    title: "Car Accident PIP Exam & Documentation | PrimaryUC",
-    description: "Car accident PIP exam & documentation at Palm Beach County urgent care. Same-day records, visit summaries & insurance paperwork. Florida 14-day compliant.",
+    title: "Florida PIP 14-Day Rule + EMC | Car Accident Exam | PrimaryUC",
+    description: "Florida PIP 14-day rule + EMC certification. Same-day car accident exam & PIP documentation in Palm Beach County. Protect your $10,000 PIP cap.",
     images: [`${baseUrl}/man-on-phone-next-to-open-hood.jpg`],
     site: '@primaryurgentcare',
   },
@@ -61,20 +100,14 @@ export default function Page() {
     url: pageUrl
   });
 
+  // FAQPage schema derived from the pipFaqs const — schema cannot drift from visible content.
   const faqObj = {
     "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: "Do I need an attorney before I come in?",
-        acceptedAnswer: { "@type": "Answer", text: "No. You can come in for an exam and documentation whether or not you have an attorney. If you decide to work with one later, we can share records once you sign a release." }
-      },
-      {
-        "@type": "Question",
-        name: "Can you update documentation over time?",
-        acceptedAnswer: { "@type": "Answer", text: "Yes. Follow-up visits generate updated records that show how your symptoms and function change over weeks or months. These can be important for ongoing claims." }
-      }
-    ]
+    mainEntity: pipFaqs.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
   };
 
   const webPageSchema = {
@@ -110,16 +143,16 @@ export default function Page() {
 
       {/* Hero Section */}
       <HeroWithForm
-        title="Car Accident PIP Documentation"
+        title="Florida PIP 14-Day Rule & Car Accident Documentation"
         subtitle={
           <p>
-            We complete a same-day post-accident exam and create the medical documentation commonly requested by insurers and attorneys.
+            Florida&apos;s PIP 14-day rule requires a qualifying medical visit within 14 days of your crash to access PIP benefits. Our car accident doctors complete the same-day exam, certify the emergency medical condition needed to unlock the full $10,000 PIP cap, and generate the documentation your insurer and any attorney will require.
           </p>
         }
         checklist={[
-          "Full exam and injury mapping for PIP claims",
-          "Same-day visit summary and records you can share",
-          "Help coordinating paperwork with insurance",
+          "Full exam + EMC certification (MD/PA/APRN) for the $10,000 PIP cap",
+          "Same-day visit summary and PIP-compliant records",
+          "Help coordinating paperwork with your insurer or attorney",
         ]}
         banner={<ImmediateCareBanner />}
         form={<AccidentAppointmentForm title="Book Your PIP Documentation Exam" noWrapper={true} showHeader={false} compact={true} />}
@@ -131,6 +164,39 @@ export default function Page() {
 
       <div className="bg-[#FAFAFA] py-12 sm:py-16 lg:py-20 px-4 sm:px-6 lg:px-8 xl:px-[60px]">
         <div className="max-w-4xl mx-auto">
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-bold text-black mb-3">What Is Florida PIP Insurance, and How Does the 14-Day Rule Work?</h2>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            Florida Personal Injury Protection (PIP) is the no-fault auto insurance coverage every Florida driver is required to carry under <strong>Fla. Stat. § 627.736</strong>. It pays for your medical care after a car accident regardless of who was at fault. The headline benefit is <strong>up to $10,000 in medical and disability coverage per accident</strong> — but that headline number comes with two conditions that catch many patients off guard.
+          </p>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            <strong>Condition 1 — the 14-day rule.</strong> You must receive an initial medical evaluation within 14 days of the date of the accident. The clock counts from the crash date, not the day your symptoms appeared. If you wait beyond day 14, your PIP carrier can deny the entire medical portion of your claim.
+          </p>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            <strong>Condition 2 — the Emergency Medical Condition (EMC) determination.</strong> The full $10,000 cap is only available when a qualifying provider certifies that you have an emergency medical condition. Without an EMC determination, PIP medical benefits are capped at <strong>$2,500</strong>. We cover the EMC requirement in detail below.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-bold text-black mb-3">Emergency Medical Condition (EMC) — The $10,000 vs $2,500 Question</h2>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            An Emergency Medical Condition is a clinical determination that your injuries manifest as acute symptoms severe enough that, without immediate medical attention, they could reasonably result in serious jeopardy to your health, serious impairment of bodily functions, or serious dysfunction of any bodily organ or part. This is the definition Florida PIP law adopts from <strong>Fla. Stat. § 395.002(8)</strong>. Under <strong>Fla. Stat. § 627.736(1)(a)</strong>, only a limited list of providers can certify an EMC:
+          </p>
+          <ul className="list-disc ml-6 space-y-2 mb-6">
+            <li>Medical doctor (MD)</li>
+            <li>Osteopathic physician (DO)</li>
+            <li>Dentist</li>
+            <li>Physician assistant (PA)</li>
+            <li>Advanced practice registered nurse (APRN)</li>
+          </ul>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            <strong>Chiropractors and physical therapists cannot certify an EMC under Florida law</strong> — they can satisfy the 14-day rule for initial services, but they cannot make the determination that unlocks the full $10,000 PIP medical cap. If your initial visit after a crash is with a chiropractor or PT only, your PIP medical benefit is limited to $2,500 unless and until a qualifying provider (MD, DO, PA, APRN, or dentist) certifies an emergency medical condition — which a qualifying provider can do at a later visit or through records review.
+          </p>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            At PrimaryUC, your visit is with a qualifying medical provider. If the EMC determination is appropriate based on your examination findings, we make it at the time of your visit and document it in the medical record your PIP carrier will receive.
+          </p>
+        </section>
 
         <section className="mb-8">
           <h2 className="text-2xl font-bold text-black mb-3">What Your PIP Exam Includes</h2>
@@ -253,19 +319,8 @@ export default function Page() {
         />
 
         <AccidentFAQ
-          title="PIP & Documentation FAQs"
-          faqs={[
-            {
-              question: "Do I need an attorney before I come in?",
-              answer:
-                "No. You can come in for an exam and documentation whether or not you have an attorney. If you decide to work with one later, we can share records once you sign a release."
-            },
-            {
-              question: "Can you update documentation over time?",
-              answer:
-                "Yes. Follow-up visits generate updated records that show how your symptoms and function change over weeks or months. These can be important for ongoing claims."
-            }
-          ]}
+          title="Florida PIP, the 14-Day Rule & EMC — Frequently Asked Questions"
+          faqs={pipFaqs}
         />
 
         {/* Internal Links Section */}

--- a/app/car-accident/urgent-care-vs-er/page.tsx
+++ b/app/car-accident/urgent-care-vs-er/page.tsx
@@ -13,15 +13,54 @@ import { toJsonLd, buildBreadcrumb, buildServiceSchema, buildGraphSchema } from 
 
 const baseUrl = "https://primaryuc.com";
 
+// Single source of truth for visible FAQ + JSON-LD FAQPage schema.
+const ucerFaqs = [
+  {
+    question: "Should I go to urgent care or the ER after a car accident?",
+    answer:
+      "For most non-life-threatening symptoms after a car accident — whiplash, neck or back pain, headache, soft-tissue injury, joint pain, minor lacerations — urgent care is the appropriate setting. Urgent care handles the exam, on-site digital X-ray, and PIP-compliant documentation in a single visit. Go directly to the ER for severe chest pain, loss of consciousness, signs of internal bleeding, neurological deficits, uncontrolled bleeding, or any symptom that suggests a life-threatening injury. When in doubt about severity, the ER is the safer choice.",
+  },
+  {
+    question: "Should I go to the ER after a car accident if I feel fine?",
+    answer:
+      "If you have no symptoms at the scene of a crash and are clinically stable, the ER is not typically the right setting. Urgent care is the appropriate place for evaluation, documentation, and Florida 14-day PIP rule compliance — and it'll be faster, lower cost, and produce the same quality medical record. If you develop symptoms later (headache, neck pain, dizziness, abdominal pain), seek care as soon as they appear — even mild delayed-onset symptoms after a crash deserve evaluation.",
+  },
+  {
+    question: "Can I go to urgent care after a car accident in Florida?",
+    answer:
+      "Yes. Urgent care is an appropriate setting for the majority of post-accident injuries, and a PrimaryUC urgent care visit satisfies Florida's 14-day PIP rule for initial services. Our medical doctors can also certify the emergency medical condition needed to access the full $10,000 PIP medical cap — something neither a chiropractor nor a physical therapist can do under Florida law.",
+  },
+  {
+    question: "When should I go straight to the ER after a car accident?",
+    answer:
+      "Go straight to the ER or call 911 for any of these red-flag presentations: severe chest pain or trouble breathing, uncontrolled bleeding, obvious major fractures or visible deformity, loss of consciousness, seizure, confusion that persists or worsens, signs of internal bleeding (severe abdominal pain, distended belly, signs of shock), spinal-cord-injury concern (leg weakness, loss of bladder or bowel control), or any symptom that worsens rapidly. When in doubt about severity, the ER is the right call.",
+  },
+  {
+    question: "How much does urgent care vs ER cost after a car accident?",
+    answer:
+      "Urgent care visits are typically a fraction of the cost of an ER visit for the same complaint. ER visits carry higher facility fees, separate physician fees, and often involve hospital-grade billing even for non-life-threatening complaints. Both settings are typically covered by Florida PIP when the visit is documented as reasonable and medically necessary — but cost-effectiveness still matters because PIP medical benefits are capped at $10,000 (with EMC certification) or $2,500 (without), and ER charges can consume that budget rapidly. For exact pricing in your situation, contact our front desk or your insurance carrier.",
+  },
+  {
+    question: "Does Florida PIP cover both urgent care and ER visits?",
+    answer:
+      "Yes. Florida PIP (Personal Injury Protection) coverage applies to both urgent care and emergency room visits when the care is reasonable, medically necessary, and related to the crash — provided you receive initial services within 14 days of the accident. Both settings can satisfy the 14-day rule. The $10,000 vs $2,500 PIP medical cap is determined by whether a qualifying provider (MD, DO, PA, APRN, or dentist) certifies an emergency medical condition — not by which setting you visited.",
+  },
+  {
+    question: "How long do you wait at urgent care vs the ER after a car accident?",
+    answer:
+      "Urgent care wait times for car accident patients are typically much shorter than ER wait times for the same complaint. Most urgent cares treat by arrival order within urgency level; ERs treat strictly by triage severity, which means a stable post-accident patient with neck pain often waits behind life-threatening cases. At PrimaryUC, we accept walk-ins and prioritize accident-related visits. For exact current wait times, call ahead to your nearest location.",
+  },
+];
+
 export const metadata: Metadata = {
-  title: "Car Accident: Urgent Care vs ER | Palm Beach Guide",
+  title: "Urgent Care or ER After a Car Accident? | Palm Beach Guide",
   description:
-    "Urgent care vs ER after car accident in Palm Beach County. When UC is safe, when ER is critical, cost comparison, wait times, PIP coverage. Florida 14-day rule.",
+    "Should you go to urgent care or the ER after a car accident? Florida PIP-aware guide to when UC is safe, when ER is required, costs, wait times, and 14-day rule.",
   alternates: { canonical: `${baseUrl}/car-accident/urgent-care-vs-er` },
   openGraph: {
-    title: "Car Accident: Urgent Care vs ER | Palm Beach Guide",
+    title: "Urgent Care or ER After a Car Accident? | Palm Beach Guide",
     description:
-      "Urgent care vs ER after car accident in Palm Beach County. When UC is safe, when ER is critical, cost comparison, wait times, PIP coverage. Florida 14-day rule.",
+      "Should you go to urgent care or the ER after a car accident? Florida PIP-aware guide to when UC is safe, when ER is required, costs, wait times, and 14-day rule.",
     url: `${baseUrl}/car-accident/urgent-care-vs-er`,
     type: 'article',
     siteName: "Primary & Urgent Care Centers",
@@ -30,15 +69,15 @@ export const metadata: Metadata = {
         url: `${baseUrl}/car-crash-woman-on-call.jpg`,
         width: 1200,
         height: 630,
-        alt: "Decision guide: urgent care vs emergency room after car accident in Palm Beach County",
+        alt: "Urgent care vs ER after a car accident decision guide for Palm Beach County drivers",
       },
     ],
     locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
-    title: "Car Accident: Urgent Care vs ER | Palm Beach Guide",
-    description: "Urgent care vs ER after a car accident in Palm Beach County. Cost, wait times & PIP coverage compared. Know when UC is safe vs when ER is critical.",
+    title: "Urgent Care or ER After a Car Accident? | Palm Beach Guide",
+    description: "Urgent care or ER after a car accident? Florida PIP-aware decision guide with red-flag list, costs, wait times, and 14-day rule compliance.",
     images: [`${baseUrl}/car-crash-woman-on-call.jpg`],
     site: '@primaryurgentcare',
   },
@@ -61,30 +100,14 @@ export default function Page() {
     url: pageUrl
   });
 
+  // FAQPage schema derived from the ucerFaqs const — schema cannot drift from visible content.
   const faqSchemaObj = {
     "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: "When is urgent care appropriate after a car accident?",
-        acceptedAnswer: { "@type": "Answer", text: "Urgent care is typically appropriate for stable patients with pain, cuts, bruises, suspected sprains or simple fractures, and mild head or whiplash symptoms without red-flag signs like severe chest pain, major bleeding, or difficulty breathing. Our team can evaluate your condition and determine if urgent care is right for you." }
-      },
-      {
-        "@type": "Question",
-        name: "When should I go straight to the ER?",
-        acceptedAnswer: { "@type": "Answer", text: "Go straight to the ER or call 911 if you have severe chest pain, trouble breathing, uncontrolled bleeding, obvious fractures with deformity, loss of consciousness, confusion, seizure, or signs of spinal cord injury. When in doubt about the severity of your condition, it's always safer to err on the side of caution and seek emergency care." }
-      },
-      {
-        "@type": "Question",
-        name: "How do costs compare between urgent care and the ER?",
-        acceptedAnswer: { "@type": "Answer", text: "Urgent care visits usually cost a fraction of ER visits. Many insured patients pay an urgent care copay similar to a primary-care visit, while ER visits often carry much higher facility fees and deductibles. Most urgent care visits for car accidents range from $100-$300, while ER visits typically cost $1,000-$3,000 or more for similar conditions." }
-      },
-      {
-        "@type": "Question",
-        name: "Does PIP cover both urgent care and ER?",
-        acceptedAnswer: { "@type": "Answer", text: "Yes. Florida PIP coverage can apply to both urgent care and ER visits when related to the crash, as long as you seek medical care within 14 days. Both options meet the PIP requirement, but urgent care often provides better value with faster service and lower costs while delivering the same quality documentation for your claim." }
-      }
-    ]
+    mainEntity: ucerFaqs.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
   };
 
   const webPageSchema = {
@@ -121,16 +144,16 @@ export default function Page() {
 
       {/* Hero Section */}
       <HeroWithForm
-        title="Urgent Care vs ER After a Car Accident"
+        title="Urgent Care or ER After a Car Accident? — Palm Beach Guide"
         subtitle={
           <p>
-            Not every crash requires the ER. We help you understand when urgent care is safe, when the ER is critical, and how both options work with PIP.
+            Not every crash requires the ER, and not every crash should default to urgent care either. This guide walks through when urgent care is the appropriate setting, when the ER is required, the cost and wait-time differences, and how Florida PIP applies to both — including the emergency medical condition determination that controls your $10,000 vs $2,500 PIP medical cap.
           </p>
         }
         checklist={[
-          "Guidance on where to go based on your symptoms",
-          "Shorter wait times and lower costs for appropriate cases",
-          "Full documentation for PIP and insurance claims",
+          "Red-flag list for ER-level symptoms",
+          "Florida 14-day PIP rule applies to both settings",
+          "EMC certification by a qualifying medical provider",
         ]}
         banner={<ImmediateCareBanner />}
         form={<AccidentAppointmentForm title="Check If Urgent Care Is Right for You" noWrapper={true} showHeader={false} compact={true} />}
@@ -178,33 +201,33 @@ export default function Page() {
         </section>
 
         <section className="mb-8">
-          <h2 className="text-2xl font-bold text-black mb-3">Cost & Wait Time Comparison</h2>
+          <h2 className="text-2xl font-bold text-black mb-3">Cost &amp; Wait Time — Urgent Care vs ER After a Car Accident</h2>
           <p className="text-base md:text-lg text-gray-700 mb-4">
-            Every situation is different, but understanding the differences can help you make an informed decision:
+            Specific cost and wait times vary by facility, insurance, and your specific complaint. The general patterns are consistent:
           </p>
           <div className="space-y-4 mb-6">
             <div className="bg-gradient-to-br from-[#F0FDF4] to-[#DCFCE7] rounded-xl p-6 border-2 border-[#16A34A]/20">
-              <h3 className="text-xl font-semibold text-gray-900 mb-2">Urgent Care Advantages</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Urgent Care After a Car Accident</h3>
               <ul className="list-disc ml-6 space-y-2 text-gray-700">
-                <li><strong>Wait times:</strong> Typically 15-30 minutes for most patients</li>
-                <li><strong>Cost:</strong> Lower copays (often $20-$50) and facility fees compared to ER</li>
-                <li><strong>Total visit cost:</strong> Usually $100-$300 for car accident evaluation</li>
-                <li><strong>Service:</strong> Focused on your specific injury without emergency room delays</li>
+                <li><strong>Wait times:</strong> Typically much shorter than the ER for non-life-threatening complaints — walk-in queueing rather than acuity-based triage</li>
+                <li><strong>Cost:</strong> Lower facility fees and copays than the ER for a comparable visit</li>
+                <li><strong>Scope:</strong> Exam, on-site digital X-ray, and PIP-compliant documentation in a single visit</li>
+                <li><strong>EMC certification:</strong> Available when your medical doctor determines you have an emergency medical condition — this is the determination that unlocks your full $10,000 Florida PIP medical cap</li>
               </ul>
             </div>
             <div className="bg-gradient-to-br from-[#FEF2F2] to-[#FEE2E2] rounded-xl p-6 border-2 border-[#D52128]/20">
-              <h3 className="text-xl font-semibold text-gray-900 mb-2">Emergency Room Considerations</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Emergency Room After a Car Accident</h3>
               <ul className="list-disc ml-6 space-y-2 text-gray-700">
-                <li><strong>Wait times:</strong> Can be 2-6 hours or more for non-life-threatening conditions</li>
-                <li><strong>Cost:</strong> Higher facility fees ($500-$1,500+) and deductibles</li>
-                <li><strong>Total visit cost:</strong> Typically $1,000-$3,000+ for similar conditions</li>
-                <li><strong>Priority:</strong> ERs must prioritize by severity, so stable patients wait longer</li>
+                <li><strong>Wait times:</strong> Variable and acuity-based — stable patients with non-life-threatening complaints typically wait substantially longer than at urgent care, because the ER must prioritize critical cases first</li>
+                <li><strong>Cost:</strong> Higher facility fees, separate physician fees, and hospital-grade billing — even for non-emergent presentations</li>
+                <li><strong>Scope:</strong> The right setting when a life-threatening injury is possible — CT/MRI on demand, surgical consults, intensive monitoring</li>
+                <li><strong>PIP impact:</strong> ER charges can consume a significant share of your $10,000 PIP medical cap quickly, leaving less budget for follow-up imaging, specialist visits, and rehabilitation</li>
               </ul>
             </div>
             <div className="bg-gradient-to-br from-[#F2F6FC] to-[#E8F2FF] rounded-xl p-6 border-2 border-[#2563eb]/20">
-              <h3 className="text-xl font-semibold text-gray-900 mb-2">PIP Coverage for Both</h3>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Florida PIP Covers Both Settings</h3>
               <p className="text-gray-700">
-                Florida PIP coverage can apply to both urgent care and ER visits when related to the crash, as long as you are evaluated within 14 days of the crash. Both options meet the PIP requirement, but urgent care often provides better value with faster service and lower costs while delivering the same quality documentation for your claim.
+                Florida PIP applies to both urgent care and ER visits when the care is reasonable, medically necessary, and related to the crash — provided the initial visit happens within 14 days of the accident. The $10,000 vs $2,500 PIP medical cap is determined by whether a qualifying provider (MD, DO, PA, APRN, or dentist) certifies an emergency medical condition, not by which setting you visited. See our <Link className="text-[#2563eb] underline hover:text-[#1d4ed8]" href="/car-accident/documentation-pip">PIP documentation and 14-day rule guide</Link> for the full breakdown.
               </p>
             </div>
           </div>
@@ -222,24 +245,8 @@ export default function Page() {
 
       {/* FAQ Section */}
       <AccidentFAQ
-        faqs={[
-          {
-            question: "When is urgent care appropriate after a car accident?",
-            answer: "Urgent care is typically appropriate for stable patients with pain, cuts, bruises, suspected sprains or simple fractures, and mild head or whiplash symptoms without red-flag signs like severe chest pain, major bleeding, or difficulty breathing. Our team can evaluate your condition and determine if urgent care is right for you."
-          },
-          {
-            question: "When should I go straight to the ER?",
-            answer: "Go straight to the ER or call 911 if you have severe chest pain, trouble breathing, uncontrolled bleeding, obvious fractures with deformity, loss of consciousness, confusion, seizure, or signs of spinal cord injury. When in doubt about the severity of your condition, it's always safer to err on the side of caution and seek emergency care."
-          },
-          {
-            question: "How do costs compare between urgent care and the ER?",
-            answer: "Urgent care visits usually cost a fraction of ER visits. Many insured patients pay an urgent care copay similar to a primary-care visit, while ER visits often carry much higher facility fees and deductibles. Most urgent care visits for car accidents range from $100-$300, while ER visits typically cost $1,000-$3,000 or more for similar conditions."
-          },
-          {
-            question: "Does PIP cover both urgent care and ER?",
-            answer: "Yes. Florida PIP coverage can apply to both urgent care and ER visits when related to the crash, as long as you seek medical care within 14 days. Both options meet the PIP requirement, but urgent care often provides better value with faster service and lower costs while delivering the same quality documentation for your claim."
-          }
-        ]}
+        title="Urgent Care or ER After a Car Accident — Frequently Asked Questions"
+        faqs={ucerFaqs}
       />
 
       {/* Internal Links Section */}

--- a/app/car-accident/whiplash/page.tsx
+++ b/app/car-accident/whiplash/page.tsx
@@ -2,6 +2,48 @@ import { Metadata } from "next";
 import { toJsonLd, buildBreadcrumb, buildServiceSchema, buildGraphSchema } from "@/lib/seo";
 
 const baseUrl = 'https://primaryuc.com';
+
+// Single source of truth for visible FAQ + JSON-LD FAQPage schema.
+// Round 2 (Feb 2026) flagged schema/visible-content mismatch as the rich-results blocker;
+// keeping this array referenced by both component and schema prevents drift.
+const whiplashFaqs = [
+  {
+    question: "How long does whiplash last after a car accident?",
+    answer:
+      "Most whiplash injuries improve within 2 to 6 weeks with appropriate care, though symptoms typically build over the first 24 to 72 hours before they start to ease. More significant soft-tissue injury can take several months to fully resolve, and a small share of patients develop chronic neck pain after whiplash that lasts longer than three months, and a smaller subset have symptoms that persist past six months. Early evaluation and a documented treatment plan reduce the risk of long-term symptoms.",
+  },
+  {
+    question: "What are the signs of whiplash after a car accident?",
+    answer:
+      "The most common signs of whiplash after a car accident are neck pain, neck stiffness, reduced range of motion, headache, dizziness, jaw discomfort, and shoulder pain. Some patients also experience tingling or numbness down the arms and hands. Symptoms frequently don't appear at the scene of the crash — they build over the next 12 to 72 hours as inflammation peaks. If you walked away from a crash feeling fine and now have any of these symptoms, you should be seen.",
+  },
+  {
+    question: "How to treat whiplash from a car accident?",
+    answer:
+      "Whiplash treatment after a car accident typically combines short-term pain control (anti-inflammatory medications, ice or heat as appropriate), gentle range-of-motion exercises started early, and graduated activity rather than prolonged rest or immobilization. Severe cases may need physical therapy referral or imaging to rule out disc injury. At PrimaryUC, your car accident doctor will examine your neck, screen for nerve involvement, image if indicated, and walk you through a recovery plan plus self-care steps you can start at home.",
+  },
+  {
+    question: "Do I need an X-ray or MRI for whiplash?",
+    answer:
+      "Imaging depends on your exam and symptoms. X-ray helps rule out cervical fracture, and MRI is recommended when there's concern for disc injury, ligament tear, or nerve compression — for example, when symptoms include arm numbness, tingling, weakness, or severe neck pain. We have onsite digital X-ray and can read it during your visit; MRI referrals are coordinated when indicated.",
+  },
+  {
+    question: "Why should I see a whiplash injury doctor instead of just a chiropractor?",
+    answer:
+      "Both medical doctors and chiropractors can satisfy Florida's 14-day PIP rule for initial services, but only a medical doctor, osteopathic physician, dentist, physician assistant, or advanced practice registered nurse can certify the emergency medical condition needed to access the full $10,000 PIP medical benefit. Without that certification, PIP benefits are capped at $2,500. A medical evaluation also includes imaging and nerve checks that fall outside the chiropractic scope. Chiropractic care can be a valuable follow-up for soft-tissue rehabilitation after the initial medical workup is complete.",
+  },
+  {
+    question: "When does whiplash become chronic neck pain?",
+    answer:
+      "When whiplash symptoms persist beyond about three months, the condition is typically described as chronic neck pain. Persistence past roughly six months is sometimes referred to in the medical literature as late whiplash syndrome. Risk factors for chronification include severe initial symptoms, pre-existing neck problems, delayed evaluation, and inadequate early treatment. Catching whiplash early, documenting it properly, and following through with treatment significantly reduces the risk of ongoing chronic neck pain.",
+  },
+  {
+    question: "Can whiplash symptoms get worse over time?",
+    answer:
+      "Yes — particularly in the first few days. Adrenaline at the scene of a crash typically masks pain, and inflammation from soft-tissue injury peaks at 24 to 72 hours. It's common for patients who felt fine at the scene to wake up with significantly worse stiffness and pain the next morning, with symptoms continuing to intensify for several days. Documenting symptom progression with an early medical visit also matters for any PIP or personal injury claim.",
+  },
+];
+
 import HeroWithForm from "@/components/accident/HeroWithForm";
 import ImmediateCareBanner from "@/components/accident/ImmediateCareBanner";
 import AccidentAppointmentForm from "@/components/accident/AccidentAppointmentForm";
@@ -12,11 +54,11 @@ import TrustBadges from "@/components/accident/TrustBadges";
 import AccidentInternalLinks from "@/components/accident/AccidentInternalLinks";
 
 export const metadata: Metadata = {
-  title: "Whiplash Treatment | Car Accident & PIP Exam | PrimaryUC",
-  description: "Whiplash treatment at Palm Beach County urgent care. Same-day neck exam, X-ray & PIP documentation. Florida 14-day rule. Walk-ins welcome.",
+  title: "Whiplash Treatment After Car Accident | Palm Beach Doctor | PrimaryUC",
+  description: "Whiplash treatment & same-day exam after a car accident in Palm Beach County. Onsite X-ray, PIP documentation, recovery plan. Walk-ins welcome at 4 locations.",
   openGraph: {
-    title: "Whiplash Treatment | Car Accident & PIP Exam | PrimaryUC",
-    description: "Whiplash treatment at Palm Beach County urgent care. Same-day neck exam, X-ray & PIP documentation. Florida 14-day rule. Walk-ins welcome.",
+    title: "Whiplash Treatment After Car Accident | Palm Beach Doctor | PrimaryUC",
+    description: "Whiplash treatment & same-day exam after a car accident in Palm Beach County. Onsite X-ray, PIP documentation, recovery plan. Walk-ins welcome at 4 locations.",
     url: `${baseUrl}/car-accident/whiplash`,
     type: "website",
     images: [
@@ -24,15 +66,15 @@ export const metadata: Metadata = {
         url: `${baseUrl}/whiplash-hero-image.png`,
         width: 1200,
         height: 630,
-        alt: "Whiplash neck pain evaluation after car accident in Palm Beach County urgent care",
+        alt: "Whiplash injury doctor performing neck range-of-motion exam on car accident patient in Palm Beach County urgent care",
       },
     ],
     locale: 'en_US',
   },
   twitter: {
     card: 'summary_large_image',
-    title: "Whiplash Treatment | Car Accident & PIP Exam | PrimaryUC",
-    description: "Whiplash treatment at Palm Beach County urgent care. Same-day neck exam, X-ray & PIP documentation. Florida 14-day rule. Walk-ins welcome.",
+    title: "Whiplash Treatment After Car Accident | Palm Beach Doctor | PrimaryUC",
+    description: "Whiplash treatment & same-day exam after a car accident in Palm Beach County. Onsite X-ray, PIP documentation, recovery plan. Walk-ins welcome at 4 locations.",
     images: [`${baseUrl}/whiplash-hero-image.png`],
     site: '@primaryurgentcare',
   },
@@ -95,35 +137,14 @@ export default function Page() {
     }
   };
 
+  // FAQPage schema derived from the whiplashFaqs const above — schema cannot drift from visible content.
   const faqObj = {
     "@type": "FAQPage",
-    mainEntity: [
-      {
-        "@type": "Question",
-        name: "Can whiplash symptoms start days after a car accident?",
-        acceptedAnswer: { "@type": "Answer", text: "Yes. Neck pain, stiffness, headaches, and dizziness may appear hours or even days after the crash. This is why it is important to be evaluated even if you feel 'okay' right after the accident. Early evaluation helps document the timeline for insurance purposes." }
-      },
-      {
-        "@type": "Question",
-        name: "Do I need X-ray or MRI for whiplash?",
-        acceptedAnswer: { "@type": "Answer", text: "Your provider will decide based on your exam and symptoms. X-ray can help rule out fractures, and MRI may be recommended if there is concern for disc or soft-tissue injury. We have onsite X-ray capabilities and can provide same-day results." }
-      },
-      {
-        "@type": "Question",
-        name: "How long does whiplash recovery typically take?",
-        acceptedAnswer: { "@type": "Answer", text: "Many people improve within 2–6 weeks with appropriate care. Some injuries take longer, especially if there is significant soft-tissue damage. Early evaluation, treatment, and follow-up can help reduce the risk of long-term symptoms." }
-      },
-      {
-        "@type": "Question",
-        name: "Is it safe to drive with whiplash?",
-        acceptedAnswer: { "@type": "Answer", text: "It depends on your pain, range of motion, and whether you have dizziness or neurologic symptoms. Your provider will advise you based on your exam and can provide documentation for work or driving restrictions if needed." }
-      },
-      {
-        "@type": "Question",
-        name: "Can whiplash symptoms get worse over time?",
-        acceptedAnswer: { "@type": "Answer", text: "Yes. It is common for soreness and stiffness to increase over the first few days. Early care can help manage pain and prevent some long-term problems. Proper documentation of symptom progression is also important for insurance claims." }
-      }
-    ]
+    mainEntity: whiplashFaqs.map((f) => ({
+      "@type": "Question",
+      name: f.question,
+      acceptedAnswer: { "@type": "Answer", text: f.answer },
+    })),
   };
 
   const graphSchema = buildGraphSchema([
@@ -143,16 +164,16 @@ export default function Page() {
 
       {/* Hero Section */}
       <HeroWithForm
-        title="Whiplash After a Car Accident"
+        title="Whiplash Treatment After a Car Accident — Palm Beach County"
         subtitle={
           <p>
-            Neck pain, stiffness, or headaches after a crash can be a sign of whiplash. Our car-accident doctors evaluate your neck, rule out serious injury, and document everything for PIP and insurance.
+            Neck pain, stiffness, or headaches after a crash can be a sign of whiplash. Our whiplash injury doctors examine your neck, screen for nerve involvement, X-ray to rule out fracture, and document everything for your PIP claim — all in a single same-day visit.
           </p>
         }
         checklist={[
           "Comprehensive neck mobility and neurologic exam",
           "Onsite X-ray; MRI referrals when indicated",
-          "Clear recovery plan and PIP-ready documentation",
+          "Whiplash recovery plan and PIP-ready documentation",
         ]}
         banner={<ImmediateCareBanner />}
         form={<AccidentAppointmentForm title="Book Your Whiplash Exam" noWrapper={true} showHeader={false} compact={true} />}
@@ -166,31 +187,33 @@ export default function Page() {
         <div className="max-w-4xl mx-auto">
 
         <section className="mb-8">
-          <h2 className="text-2xl font-bold text-black mb-3">Symptoms After a Car Accident</h2>
+          <h2 className="text-2xl font-bold text-black mb-3">Signs of Whiplash After a Car Accident</h2>
           <p className="text-base md:text-lg text-gray-700 mb-4">
-            Whiplash and neck injuries can cause a variety of symptoms. Here's what to watch for:
+            Whiplash injury symptoms are typically caused by a rapid back-and-forth motion of the neck — the same motion produced by a rear-end, side-impact, or sudden-stop crash. Here are the signs of whiplash after a car accident our doctors evaluate most often:
           </p>
           <div className="mb-6">
-            <h3 className="text-xl font-semibold text-gray-900 mb-3">Neck & Whiplash Symptoms</h3>
+            <h3 className="text-xl font-semibold text-gray-900 mb-3">Whiplash Injury Symptoms to Watch For</h3>
             <ul className="list-disc ml-6 space-y-2 mb-4">
-              <li>Neck pain, stiffness, or reduced range of motion</li>
-              <li>Headaches, dizziness, jaw pain, or shoulder pain</li>
-              <li>Symptoms that begin hours or days after the crash</li>
-              <li>Numbness, tingling, or weakness in arms or hands</li>
-              <li>Trouble concentrating, feeling "foggy," or sleep disturbances</li>
+              <li><strong>Whiplash neck pain</strong> — soreness, sharp pain, or stiffness when turning the head</li>
+              <li>Reduced range of motion (turning, looking up, looking down)</li>
+              <li>Headaches at the base of the skull or radiating to the temples</li>
+              <li>Dizziness, jaw pain (TMJ irritation), or shoulder pain</li>
+              <li><strong>Whiplash nerve damage symptoms</strong> — numbness, tingling, or weakness in the arms or hands</li>
+              <li>Symptoms that begin hours or days after the crash, not immediately</li>
+              <li>Trouble concentrating, feeling &quot;foggy,&quot; or sleep disturbances</li>
             </ul>
           </div>
         </section>
 
         <section className="mb-8">
-          <h2 className="text-2xl font-bold text-black mb-3">Whiplash Symptom Timeline</h2>
+          <h2 className="text-2xl font-bold text-black mb-3">Whiplash Symptom Timeline — When Does Pain Start?</h2>
           <p className="text-base md:text-lg text-gray-700 mb-4">
-            Many people feel only shaken or sore immediately after a crash. Whiplash symptoms often build over the next 24–72 hours. Seeking care early creates a documented timeline that links your symptoms to the collision and allows your provider to rule out more serious problems.
+            Most patients feel only shaken or sore immediately after a crash. Adrenaline at the scene typically suppresses pain for several hours, and inflammation from the soft-tissue injury then builds over the following 24 to 72 hours. Seeking care early creates a documented timeline that links your symptoms to the collision and allows a provider to rule out more serious problems.
           </p>
           <div className="bg-gradient-to-br from-[#FEF2F2] to-[#FEE2E2] rounded-xl p-6 border-2 border-[#D52128]/20">
-            <h3 className="text-lg font-semibold text-gray-900 mb-3">Most patients don't feel pain until the next day</h3>
+            <h3 className="text-lg font-semibold text-gray-900 mb-3">Most patients don&apos;t feel whiplash pain until the next day</h3>
             <p className="text-gray-700 mb-4">
-              This delayed onset is common with whiplash injuries. Even if you feel fine immediately after the accident, symptoms like neck stiffness, headaches, and pain often appear 12-48 hours later. Early evaluation helps document the connection between the crash and your symptoms for insurance purposes.
+              Delayed-onset pain is common with whiplash injuries. Even if you feel fine immediately after the accident, neck stiffness, headaches, and pain often appear 12 to 48 hours later. Early evaluation matters for two reasons: it documents the connection between the crash and your symptoms for your PIP claim, and Florida&apos;s 14-day PIP rule starts counting from the date of the accident, not the date your symptoms appeared.
             </p>
           </div>
         </section>
@@ -221,16 +244,45 @@ export default function Page() {
         </section>
 
         <section className="mb-8">
-          <h2 className="text-2xl font-bold text-black mb-3">Treatment Options</h2>
+          <h2 className="text-2xl font-bold text-black mb-3">How to Treat Whiplash After a Car Accident</h2>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            Whiplash treatment combines short-term pain management with graduated activity rather than prolonged rest or rigid immobilization. The current evidence base — including guidance from the Quebec Task Force on Whiplash-Associated Disorders and contemporary musculoskeletal literature — supports the following approach:
+          </p>
           <ul className="list-disc ml-6 space-y-2 mb-6">
-            <li>Pain and anti-inflammatory medications as appropriate</li>
-            <li>Guided stretches and gentle neck exercises</li>
-            <li>Advice on safe activity and return-to-work timelines</li>
-            <li>Referral for physical therapy or specialist care if needed</li>
-            <li>
-              Ongoing follow-up to monitor recovery and adjust the plan over time
-            </li>
+            <li><strong>Anti-inflammatory medications</strong> (NSAIDs) for the first 1–2 weeks, dosed as appropriate to your medical history</li>
+            <li><strong>Ice in the first 48–72 hours</strong> to reduce acute swelling; heat thereafter for muscle relaxation</li>
+            <li><strong>Gentle range-of-motion exercises</strong> started early — long periods of rest or hard cervical collars are no longer recommended for most whiplash injuries</li>
+            <li><strong>Whiplash injury self-care</strong> — sleep posture adjustments, gradual return to normal activity, avoiding sudden head movements during the acute phase</li>
+            <li><strong>Physical therapy referral</strong> when symptoms persist past 2 weeks or when range-of-motion remains significantly limited</li>
+            <li><strong>Specialist referral</strong> (orthopedic spine, neurology) for any patient with persistent radicular symptoms — arm numbness, weakness, or pain shooting down a limb</li>
+            <li><strong>Ongoing follow-up</strong> to monitor recovery and adjust the plan</li>
           </ul>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            For most whiplash injuries, the goal is to keep the neck mobile and gradually return to normal activity while controlling pain. Patients who keep moving generally recover faster than patients who immobilize.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-bold text-black mb-3">When Whiplash Becomes Chronic Neck Pain</h2>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            Most whiplash injuries resolve within 2 to 6 weeks. A meaningful minority of patients develop <strong>chronic neck pain after whiplash</strong> — typically defined as symptoms that persist beyond about three months. When symptoms continue past roughly six months, the condition is sometimes described in the medical literature as late whiplash syndrome. Risk factors for chronification include severe initial pain, pre-existing neck problems, delayed evaluation, inadequate early treatment, and high psychological distress at the time of injury.
+          </p>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            The strongest protective factors are early medical evaluation, accurate diagnosis (ruling out fracture or disc injury), early initiation of graduated activity, and consistent follow-up. If your whiplash symptoms have not improved meaningfully by 6 weeks, a re-evaluation — including MRI consideration and possible specialist referral — is warranted.
+          </p>
+        </section>
+
+        <section className="mb-8">
+          <h2 className="text-2xl font-bold text-black mb-3">Why See a Whiplash Injury Doctor and Not Just a Chiropractor</h2>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            Both medical doctors and chiropractors can satisfy <strong>Florida&apos;s 14-day PIP rule</strong> for initial services after a car accident. But only a medical doctor, osteopathic physician, dentist, physician assistant, or advanced practice registered nurse can certify the emergency medical condition needed to access the full $10,000 PIP medical benefit — without that certification, PIP medical benefits are capped at $2,500.
+          </p>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            A whiplash injury doctor at urgent care can also order and read on-site X-ray to rule out cervical fracture, refer for MRI when soft-tissue or nerve injury is suspected, manage acute pain medically, and generate the kind of PIP-compliant evaluation note your insurance carrier and any attorney you retain will need. Chiropractic care can be a valuable follow-up for soft-tissue rehabilitation — but most patients are better served starting with a medical workup that satisfies the EMC requirement and the imaging needs that fall outside the chiropractic scope.
+          </p>
+          <p className="text-base md:text-lg text-gray-700 mb-4">
+            See our <a className="text-[#2563eb] underline hover:text-[#1d4ed8]" href="/car-accident-injury-clinic">car accident injury clinic page</a> for the full picture of what an urgent care visit looks like, or our <a className="text-[#2563eb] underline hover:text-[#1d4ed8]" href="/car-accident/documentation-pip">PIP documentation guide</a> for what specifically must be in the record.
+          </p>
         </section>
 
         <RelatedTopics 
@@ -242,28 +294,8 @@ export default function Page() {
         />
 
         <AccidentFAQ
-          faqs={[
-            {
-              question: "Can whiplash symptoms start days after a car accident?",
-              answer: "Yes. Neck pain, stiffness, headaches, and dizziness may appear hours or even days after the crash. This is why it is important to be evaluated even if you feel 'okay' right after the accident. Early evaluation helps document the timeline for insurance purposes."
-            },
-            {
-              question: "Do I need X-ray or MRI for whiplash?",
-              answer: "Your provider will decide based on your exam and symptoms. X-ray can help rule out fractures, and MRI may be recommended if there is concern for disc or soft-tissue injury. We have onsite X-ray capabilities and can provide same-day results."
-            },
-            {
-              question: "How long does whiplash recovery typically take?",
-              answer: "Many people improve within 2–6 weeks with appropriate care. Some injuries take longer, especially if there is significant soft-tissue damage. Early evaluation, treatment, and follow-up can help reduce the risk of long-term symptoms."
-            },
-            {
-              question: "Is it safe to drive with whiplash?",
-              answer: "It depends on your pain, range of motion, and whether you have dizziness or neurologic symptoms. Your provider will advise you based on your exam and can provide documentation for work or driving restrictions if needed."
-            },
-            {
-              question: "Can whiplash symptoms get worse over time?",
-              answer: "Yes. It is common for soreness and stiffness to increase over the first few days. Early care can help manage pain and prevent some long-term problems. Proper documentation of symptom progression is also important for insurance claims."
-            }
-          ]}
+          title="Whiplash After a Car Accident — Frequently Asked Questions"
+          faqs={whiplashFaqs}
         />
 
         {/* Internal Links Section */}


### PR DESCRIPTION
## Summary

SEO Round 3 — layers content-level keyword targeting on top of the schema/metadata foundation from Rounds 1–2 (Feb 2026). Targets ~21,000 monthly searches across the `/car-accident*` topic cluster at KD ≤ 6. Pre-edit Ahrefs showed the cluster ranked for 1 organic kw (vol 30, pos 10, 0 traffic) and the domain ranked for 12 kw total — zero car-accident-related.

Full audit doc lives in the agency workspace at `accounts/primary-urgent-care/seo/2026-05-22-car-accident-landing-page-audit.md`.

## What changed — page by page

| Route | Headline change |
| --- | --- |
| `/car-accident-injury-clinic` (hub) | Metadata leads with "car accident doctor" (1,400 vol). 2 new H2 sections. AccidentSEOContent rewritten with Tier 1 kw + EMC clarification. 7-question FAQ replacing 5 defaults. FAQ schema derived from same const. |
| `/car-accident/whiplash` | 3 new H2 sections (signs, chronic-vs-late-WAD, whiplash-injury-doctor-vs-chiropractor). Rewritten "How to Treat Whiplash" with Quebec Task Force reference. 7-question FAQ via const. EMC framing. |
| `/car-accident/back-neck-pain` | NEW FAQ section (page had none) with 7 kw-aligned questions. 2 new H2 sections (delayed back/neck pain, upper-vs-middle-vs-lower back). New "Why see a medical doctor" section with EMC framing. Consolidated duplicate spine-exam content. |
| `/car-accident/documentation-pip` | Metadata leads with "Florida PIP 14-Day Rule + EMC". 2 new H2 sections explaining PIP + EMC mechanics in detail. 7-question FAQ replacing 2 prior. EMC definition tracks Fla. Stat. § 395.002(8) statutory text exactly. |
| `/car-accident/urgent-care-vs-er` | 7-question FAQ via const. Cost/wait-time section softened — removed unverifiable specific dollar/minute figures, comparative framing only. EMC framing throughout. |
| `/car-accident/[city]` × 4 cities | FAQ consolidated to single per-page const consumed by both visible component AND JSON-LD schema. 8-question FAQ replacing 7 (new EMC Q + new chiropractor Q). Q6 weekend hours softened to defer to per-city location page. |

## Structural fix — schema/visible FAQ drift now impossible

Across all 9 pages, the visible `<AccidentFAQ />` component and the JSON-LD `FAQPage` schema both consume the same per-page const. Round 2 (Feb 2026) had to fix one schema-vs-visible mismatch; this PR makes the bug class structurally impossible without an explicit code change.

## EMC framing — the missing legal fact, now everywhere

Florida PIP statute § 627.736(1)(a)(3-4): the $10,000 PIP medical cap is only available when MD/DO/PA/APRN/dentist certifies an Emergency Medical Condition. Without it, PIP caps at $2,500. Chiropractors and PTs cannot certify EMC. **This is the page's strongest practical differentiator over lawyer-firm competitor pages**, and was missing entirely before this PR.

## NEW process — adversarial fact-check via dedicated subagent

Every page was reviewed by a separate `blog-fact-checker` subagent before commit. The subagent has its own system prompt biased toward finding errors, no attachment to specific phrasings, and verifies against primary sources only (statute text, peer-reviewed literature, agency press releases).

Catches this PR:
- **Hub** Round 1: I implied chiropractors don't satisfy the 14-day rule. Under § 627.736(1)(a)(1) they explicitly DO — the real legal distinction is EMC certification. 6 patches applied.
- **Whiplash**: I conflated "chronic neck pain" (≥3 months) with "late whiplash syndrome" (more commonly ≥6 months in literature). 3 patches applied.
- **Documentation-PIP**: My EMC definition drifted from statutory text at § 395.002(8). 2 patches applied to match exactly.
- **Back-neck-pain, urgent-care-vs-er, [city]**: PASS on first review.

Full fact-check reports preserved in the agency workspace at `accounts/primary-urgent-care/seo/*.factcheck.md`.

## Build

`npx tsc --noEmit` reports 7 errors across the edited files — **all pre-existing on `main`** (verified by stashing my changes and re-running). They're `AccidentInfoSection` `type` prop using `"primary"` / `"secondary"` vs the expected `"success" | "warning" | "info" | undefined`. Not introduced by this PR. Worth a separate cleanup PR but out of scope here.

This PR introduces **0 new TypeScript errors**.

## Operational claims needing PUC sign-off before merge

The fact-checker flagged operational claims about PUC's clinic operations that need confirmation. If any are not accurate today, the relevant sentences need to be softened or removed:

- [ ] Four locations open and accepting walk-in accident patients today (Royal Palm Beach, Lake Worth, Palm Springs, Lantana)
- [ ] All four locations actively prioritize accident-related visits
- [ ] Onsite digital X-ray at all four locations
- [ ] CT/MRI referrals coordinated when indicated
- [ ] PIP-compliant documentation routinely generated at the visit
- [ ] EMC certification offered when clinically appropriate at all four locations
- [ ] Single same-day visit workup is the standard for car accident presentations
- [ ] Specialist referral workflow (orthopedic spine, neurology) for persistent radicular symptoms (whiplash + back-neck-pain pages)
- [ ] 6-week re-evaluation + MRI consideration workflow for whiplash (whiplash page)

## Forecast

Conservative 60-day estimate after merge + deploy: ~250–500 organic clicks/mo to the cluster, vs ~0 today. Tier 1 kw at KD ≤ 6 are very winnable. Net-new traffic on top of existing paid Google Ads spend.

## Test plan

- [ ] `npm run build` passes after merge (same 32/32 static pages as Round 2)
- [ ] Rich Results Test against live URLs post-deploy — confirm Service / MedicalWebPage / FAQPage schema parse with 0 errors on hub + 4 siblings + sample city
- [ ] View page source — confirm canonical, OG title/description, H1, EMC framing all reflect new copy
- [ ] Submit URLs to Google Search Console for re-crawl
- [ ] Ahrefs re-pull at +14d, +28d, +56d to measure rank movement

## Note on history

Originally opened as PR #25 from `izzylite:israel/car-accident-seo-keywords` (wrong GitHub account on the agency workstation). #25 has been closed and this PR re-opened from `israeldev-rgb:israel/car-accident-seo-keywords` (correct account). Commits are identical; commit authorship was already `Israel <israel.dev@appflowstudio.io>` on both.