### PR TITLE
Mobile CRO: mini form hero + full-form popup on homepage & all car ac…

### DIFF
--- a/app/car-accident/[city]/page.tsx
+++ b/app/car-accident/[city]/page.tsx
@@ -12,7 +12,6 @@ import AccidentSEOContent from "@/components/accident/AccidentSEOContent";
 import AccidentFAQ from "@/components/accident/AccidentFAQ";
 import MobileCarousel from "@/components/ui/MobileCarousel";
 import FourteenDayBanner from "@/components/accident/FourteenDayBanner";
-import MobileStickyFooter from "@/components/accident/MobileStickyFooter";
 import PatientReviewsSection from "@/components/accident/PatientReviewsSection";
 import TrustBadges from "@/components/accident/TrustBadges";
 import AccidentInternalLinks from "@/components/accident/AccidentInternalLinks";
@@ -619,8 +618,6 @@ export default async function Page({ params }: { params: Promise<Params> }) {
         );
       })()}
 
-      {/* Mobile Sticky Footer */}
-      <MobileStickyFooter phoneHref={c.phoneHref} phoneDisplay={c.phoneDisplay} />
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ import Testimonials from "@/components/testimonials";
 import Reviews from "@/components/Reviews";
 import { LanguageSwitcher } from "@/components/language-switcher";
 import Link from "next/link";
-import BookAppointmentForm from "@/components/ui/BookAppointmentForm";
+import HomepageMobileHeroForm from "@/components/ui/HomepageMobileHeroForm";
 export const metadata = {
   title: 'Car Accident Doctor Palm Beach County | PrimaryUC',
   description: 'Car accident doctor in Palm Beach County. Immediate PIP exam, X-ray & documentation. Walk-ins welcome — 4 locations, seen in under 15 min.',
@@ -97,8 +97,8 @@ export default function Home() {
             </p>
           </div>
 
-          <div className=" w-full h-full ">
-            <BookAppointmentForm title="Request an appointment" bgColor="backdrop-blur-3xl lg:p-8 p-4 rounded-2xl" textColor="text-white" />
+          <div className="w-full h-full">
+            <HomepageMobileHeroForm />
           </div>
 
         </div>

--- a/components/accident/AccidentMobileFormReveal.tsx
+++ b/components/accident/AccidentMobileFormReveal.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useState, useEffect, useCallback, type ReactNode } from "react";
+import { Phone, User } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  formatUSPhoneNumber,
+  hasAtMostTenPhoneDigits,
+} from "@/lib/validation/phone";
+
+type DataLayerEvent = Record<string, string | number | boolean | null | undefined>;
+
+function pushDataLayerEvent(event: DataLayerEvent) {
+  if (typeof window === "undefined") return;
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(event);
+}
+
+interface AccidentMobileFormRevealProps {
+  phoneHref: string;
+  phoneDisplay: string;
+  children: ReactNode; // full CompactAccidentForm rendered server-side
+}
+
+export default function AccidentMobileFormReveal({
+  phoneHref,
+  phoneDisplay,
+  children,
+}: AccidentMobileFormRevealProps) {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+
+  const openDialog = useCallback(() => {
+    const path = typeof window !== "undefined" ? window.location.pathname : "";
+    const slug = path.split("/").filter(Boolean).pop() || "";
+    pushDataLayerEvent({
+      event: "car_accident_mobile_hero_form_open",
+      page_type: "car_accident_location",
+      location_slug: slug,
+      form_type: "same_day_accident_exam",
+      cta_text: "Request Exam",
+      cta_position: "mobile_hero_top_fold",
+      page_path: path,
+    });
+    setIsDialogOpen(true);
+  }, []);
+
+  const handleCallClick = useCallback(() => {
+    const path = typeof window !== "undefined" ? window.location.pathname : "";
+    const slug = path.split("/").filter(Boolean).pop() || "";
+    pushDataLayerEvent({
+      event: "car_accident_mobile_hero_call_click",
+      page_type: "car_accident_location",
+      location_slug: slug,
+      phone_number: phoneDisplay,
+      cta_text: "Call Now",
+      cta_position: "mobile_hero_top_fold",
+      page_path: path,
+    });
+  }, [phoneDisplay]);
+
+  // Sticky footer "Request Exam" dispatches this to open the dialog
+  useEffect(() => {
+    const handler = () => setIsDialogOpen(true);
+    window.addEventListener("primaryuc:expand-accident-form", handler);
+    return () => window.removeEventListener("primaryuc:expand-accident-form", handler);
+  }, []);
+
+  return (
+    <>
+      {/* ── Mobile-only hero CTA block ── */}
+      <div className="md:hidden mt-4 space-y-3">
+
+        {/* Mini form card */}
+        <div className="bg-white rounded-2xl p-5 shadow-2xl">
+          <p className="text-gray-900 font-bold text-base leading-tight mb-0.5">
+            Hurt in an accident?
+          </p>
+          <p className="text-gray-500 text-xs mb-3">
+            Same-day exams &middot; PIP accepted &middot; No referral needed
+          </p>
+
+          <div className="space-y-2.5 mb-3">
+            {/* Name */}
+            <div className="relative">
+              <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+              <input
+                type="text"
+                placeholder="Your Name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoComplete="name"
+                className="w-full h-11 pl-9 pr-3 rounded-xl border border-gray-200 bg-gray-50 text-gray-900 text-sm outline-none focus:border-[#2563eb] focus:ring-1 focus:ring-[#2563eb] transition"
+              />
+            </div>
+
+            {/* Phone */}
+            <div className="relative">
+              <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+              <input
+                type="tel"
+                inputMode="tel"
+                placeholder="Phone Number"
+                value={phone}
+                onChange={(e) => {
+                  if (hasAtMostTenPhoneDigits(e.target.value)) {
+                    setPhone(formatUSPhoneNumber(e.target.value));
+                  }
+                }}
+                autoComplete="tel"
+                className="w-full h-11 pl-9 pr-3 rounded-xl border border-gray-200 bg-gray-50 text-gray-900 text-sm outline-none focus:border-[#2563eb] focus:ring-1 focus:ring-[#2563eb] transition"
+              />
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={openDialog}
+            className="w-full h-12 bg-[#D52128] hover:bg-[#b81b22] active:bg-[#9a1520] text-white font-bold text-base rounded-xl shadow-lg touch-manipulation transition-colors duration-200"
+          >
+            Request Same-Day Exam &rarr;
+          </button>
+
+          <p className="text-[11px] text-gray-400 text-center mt-2">
+            Same-day accident exams &middot; PIP accepted &middot; No obligation
+          </p>
+        </div>
+
+        {/* Call Now — below the card */}
+        <a
+          href={phoneHref}
+          onClick={handleCallClick}
+          className="flex items-center justify-center gap-3 w-full bg-[#2563eb] hover:bg-[#1d4ed8] active:bg-[#1e40af] text-white font-bold text-base rounded-xl shadow-lg touch-manipulation transition-colors duration-200"
+          style={{ minHeight: "52px" }}
+          aria-label={`Call now: ${phoneDisplay}`}
+        >
+          <Phone className="w-5 h-5 flex-shrink-0" />
+          Call Now: {phoneDisplay}
+        </a>
+      </div>
+
+      {/* ── Full exam form dialog ── */}
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="max-h-[92dvh] overflow-y-auto w-full max-w-[calc(100%-1.5rem)] sm:max-w-lg p-0 gap-0">
+          <DialogHeader className="px-6 pt-6 pb-0">
+            <DialogTitle className="text-xl font-bold text-gray-900">
+              Request a Same-Day Accident Exam
+            </DialogTitle>
+          </DialogHeader>
+          <div className="px-4 pb-6 pt-4">
+            {children}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/components/accident/HeroWithForm.tsx
+++ b/components/accident/HeroWithForm.tsx
@@ -1,17 +1,18 @@
 import type { ReactNode } from "react";
 import Image from "next/image";
 import { Phone } from "lucide-react";
+import AccidentMobileFormReveal from "@/components/accident/AccidentMobileFormReveal";
 
 type Props = {
-  title: string;            // H1 text – render inside the component
-  kicker?: string;          // small pretitle above H1 (optional)
-  subtitle?: ReactNode;     // short paragraph under H1
-  checklist?: string[];     // bullet list shown under subtitle
-  banner?: ReactNode;       // "Need immediate care..." banner (component passed in)
-  form: ReactNode;          // appointment form ReactNode (passed in)
-  backgroundImage?: string; // custom background image (optional)
-  phoneHref?: string;       // tel: link for the hero phone CTA button
-  phoneDisplay?: string;    // display text for phone CTA
+  title: string;
+  kicker?: string;
+  subtitle?: ReactNode;
+  checklist?: string[];
+  banner?: ReactNode;
+  form: ReactNode;
+  backgroundImage?: string;
+  phoneHref?: string;
+  phoneDisplay?: string;
 };
 
 export default function HeroWithForm({
@@ -28,9 +29,8 @@ export default function HeroWithForm({
   return (
     <section
       id="accident-form"
-      className="relative w-full pt-12 md:pt-20 pb-12 min-h-[85vh] lg:min-h-[90vh] overflow-hidden"
+      className="relative w-full pt-8 md:pt-20 pb-8 md:pb-12 md:min-h-[85vh] lg:min-h-[90vh] overflow-hidden"
     >
-      {/* Background image via Next.js Image for LCP optimization */}
       <Image
         src={backgroundImage}
         alt="Car accident injury clinic"
@@ -42,35 +42,35 @@ export default function HeroWithForm({
         quality={85}
       />
 
-      {/* Dark gradient overlay — bottom-heavy for readability */}
       <div className="absolute inset-0 bg-gradient-to-b from-black/50 via-black/40 to-black/65" />
 
-      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 xl:px-[60px] h-full flex items-center py-5 md:py-8">
-        <div className="grid gap-6 md:gap-8 lg:gap-12 md:grid-cols-2 w-full items-center">
-          {/* Left Column - Content */}
-          <div className="flex flex-col space-y-4 md:space-y-5">
+      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 xl:px-[60px] h-full flex items-center py-4 md:py-8">
+        <div className="grid gap-4 md:gap-8 lg:gap-12 md:grid-cols-2 w-full items-center">
+
+          {/* Left Column */}
+          <div className="flex flex-col space-y-3 md:space-y-5">
             <div>
               {kicker && (
                 <p className="mb-2 text-sm font-medium uppercase tracking-wide text-white/80">
                   {kicker}
                 </p>
               )}
-              <h1 className="ca-fade-up text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold leading-tight text-white mb-3 md:mb-4">
+              <h1 className="ca-fade-up text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold leading-tight text-white mb-2 md:mb-4">
                 {title}
               </h1>
+
+              {/* Subtitle — desktop only; declutters mobile so form sits higher */}
               {subtitle && (
-                <div className="ca-fade-up ca-stagger-1 mt-2 md:mt-3 text-base md:text-lg text-white/90 leading-relaxed">
+                <div className="hidden md:block ca-fade-up ca-stagger-1 mt-2 md:mt-3 text-base md:text-lg text-white/90 leading-relaxed">
                   {subtitle}
                 </div>
               )}
 
+              {/* Checklist — desktop only */}
               {checklist.length > 0 && (
-                <ul className="mt-4 md:mt-5 space-y-2.5 md:space-y-3">
+                <ul className="hidden md:flex mt-4 md:mt-5 flex-col space-y-2.5 md:space-y-3">
                   {checklist.map((item, i) => (
-                    <li
-                      key={i}
-                      className={`ca-fade-up ca-stagger-${i + 1} flex items-start gap-3`}
-                    >
+                    <li key={i} className={`ca-fade-up ca-stagger-${i + 1} flex items-start gap-3`}>
                       <span className="mt-1 inline-flex h-5 w-5 md:h-6 md:w-6 shrink-0 items-center justify-center rounded-full bg-[#D52128] text-white">
                         <svg viewBox="0 0 20 20" fill="currentColor" className="h-3 w-3 md:h-4 md:w-4">
                           <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-7.5 7.5a1 1 0 01-1.414 0l-3-3a1 1 0 111.414-1.414L8.5 12.086l6.793-6.793a1 1 0 011.414 0z" clipRule="evenodd" />
@@ -83,11 +83,11 @@ export default function HeroWithForm({
               )}
             </div>
 
-            {/* Prominent phone CTA — large red button */}
+            {/* Phone CTA — desktop only */}
             {phoneHref && (
               <a
                 href={phoneHref}
-                className="ca-pulse-cta inline-flex items-center justify-center gap-3 bg-[#D52128] hover:bg-[#b81b22] active:bg-[#9a1520] text-white font-bold text-lg px-6 py-4 rounded-xl shadow-lg touch-manipulation transition-colors duration-200 w-full md:w-auto"
+                className="ca-pulse-cta hidden md:inline-flex items-center justify-center gap-3 bg-[#D52128] hover:bg-[#b81b22] active:bg-[#9a1520] text-white font-bold text-lg px-6 py-4 rounded-xl shadow-lg touch-manipulation transition-colors duration-200 md:w-auto"
                 aria-label={`Call now: ${phoneDisplay}`}
               >
                 <Phone className="w-5 h-5 flex-shrink-0" />
@@ -95,16 +95,24 @@ export default function HeroWithForm({
               </a>
             )}
 
-            {/* Banner positioned prominently in top fold */}
-            {banner && <div className="mt-2">{banner}</div>}
+            {/* Mobile: mini form card + Call Now (immediately after H1) */}
+            <AccidentMobileFormReveal
+              phoneHref={phoneHref || "tel:+15616533177"}
+              phoneDisplay={phoneDisplay || "561-653-3177"}
+            >
+              {form}
+            </AccidentMobileFormReveal>
+
+            {banner && <div className="mt-2 hidden md:block">{banner}</div>}
           </div>
 
-          {/* Right Column - Form */}
-          <div className="ca-fade-in ca-stagger-2 flex items-center justify-center md:justify-end">
+          {/* Right Column — desktop form card */}
+          <div className="hidden md:flex ca-fade-in ca-stagger-2 items-center justify-center md:justify-end">
             <div id="accident-appointment-form" className="rounded-xl border border-white/20 bg-white shadow-2xl p-4 md:p-6 w-full max-w-md scroll-mb-24">
               {form}
             </div>
           </div>
+
         </div>
       </div>
     </section>

--- a/components/accident/MobileStickyFooter.tsx
+++ b/components/accident/MobileStickyFooter.tsx
@@ -9,30 +9,43 @@ interface MobileStickyFooterProps {
 }
 
 export default function MobileStickyFooter({ phoneHref, phoneDisplay }: MobileStickyFooterProps) {
-  const scrollToForm = (event: MouseEvent<HTMLAnchorElement>) => {
+  const handleCallClick = () => {
+    if (typeof window === "undefined") return;
+    window.dataLayer = window.dataLayer || [];
+    window.dataLayer.push({
+      event: "car_accident_sticky_footer_call_click",
+      page_type: "car_accident_location",
+      phone_number: phoneDisplay,
+      cta_text: "Call Now",
+      cta_position: "mobile_sticky_footer",
+      page_path: window.location.pathname,
+    });
+  };
+
+  const handleRequestExam = (event: MouseEvent<HTMLAnchorElement>) => {
     event.preventDefault();
 
-    const form = document.getElementById("accident-appointment-form");
-    if (!form) {
-      document.getElementById("accident-form")?.scrollIntoView({ behavior: "smooth", block: "start" });
-      return;
-    }
+    // Tell AccidentMobileFormReveal to expand and scroll to the form
+    window.dispatchEvent(new CustomEvent("primaryuc:expand-accident-form"));
 
-    const stickyHeight = event.currentTarget.closest("[data-mobile-sticky-footer]")?.getBoundingClientRect().height || 88;
-    const formBottom = form.getBoundingClientRect().bottom + window.scrollY;
-    const targetY = Math.max(0, formBottom - window.innerHeight + stickyHeight + 16);
+    // Scroll to the mobile hero form after the state update renders it
+    setTimeout(() => {
+      const target =
+        document.getElementById("accident-mobile-hero-form") ||
+        document.getElementById("accident-appointment-form");
+      if (!target) return;
 
-    window.scrollTo({
-      top: targetY,
-      behavior: "smooth",
-    });
+      const stickyHeight = 88;
+      const targetTop = target.getBoundingClientRect().top + window.scrollY - stickyHeight - 16;
+      window.scrollTo({ top: Math.max(0, targetTop), behavior: "smooth" });
+    }, 120);
   };
 
   return (
     <div
       data-mobile-sticky-footer
       className="fixed bottom-0 left-0 w-full z-50 md:hidden bg-white shadow-2xl border-t-2 border-gray-200"
-      style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
     >
       {/* Micro trust line */}
       <div className="bg-gray-50 border-b border-gray-100 px-4 py-1 text-center">
@@ -43,6 +56,7 @@ export default function MobileStickyFooter({ phoneHref, phoneDisplay }: MobileSt
       <div className="px-3 py-2.5 flex items-center gap-2">
         <a
           href={phoneHref}
+          onClick={handleCallClick}
           className="flex-1 flex items-center justify-center gap-2 bg-[#D52128] hover:bg-[#b81b22] active:bg-[#9a1520] text-white font-bold py-3 rounded-xl shadow-lg touch-manipulation transition-colors duration-200"
           aria-label={`Call now: ${phoneDisplay}`}
         >
@@ -50,8 +64,8 @@ export default function MobileStickyFooter({ phoneHref, phoneDisplay }: MobileSt
           <span className="text-sm">Call Now</span>
         </a>
         <a
-          href="#accident-appointment-form"
-          onClick={scrollToForm}
+          href="#accident-mobile-hero-form"
+          onClick={handleRequestExam}
           className="flex-1 flex items-center justify-center gap-2 bg-[#2563eb] hover:bg-[#1d4ed8] active:bg-[#1e40af] text-white font-bold py-3 rounded-xl shadow-lg touch-manipulation transition-colors duration-200"
           aria-label="Request same-day accident exam"
         >

--- a/components/email/SendEmail.ts
+++ b/components/email/SendEmail.ts
@@ -9,6 +9,10 @@ import { getValidatedPhoneNumber } from '@/lib/validation/phone';
 
 const resend = new Resend(process.env.RESEND_KEY);
 
+// Internal recipients for all lead/contact notifications.
+// Add or remove addresses here to update all form flows at once.
+const PRIMARY_UC_LEAD_RECIPIENTS = ['support@primaryuc.com', 'urgentroyal@gmail.com'];
+
 async function logLeadToSupabase(data: {
   patient_name?:   string;
   patient_email?:  string;
@@ -101,7 +105,7 @@ export async function sendContactEmail(formData: { name: string, email: string, 
     const normalizedPhone = getValidatedPhoneNumber(formData.phone);
     const data = await resend.emails.send({
       from: 'Primary & Urgent Care Centers <support@primaryuc.com>',
-      to: ['support@primaryuc.com'],
+      to: PRIMARY_UC_LEAD_RECIPIENTS,
       subject: 'New Contact Form Submission',
       react: await ContactEmailTemplate({ name: formData.name, email: formData.email, phone: normalizedPhone, reason: formData.reason, accidentType: formData.accidentType }),
     });
@@ -126,7 +130,7 @@ export async function sendLawyerRecordsEmail(formData: {
     const normalizedPhone = getValidatedPhoneNumber(formData.phone);
     const data = await resend.emails.send({
       from: 'Primary & Urgent Care Centers <support@primaryuc.com>',
-      to: ['support@primaryuc.com'],
+      to: PRIMARY_UC_LEAD_RECIPIENTS,
       subject: 'New Medical Records Request from Attorney',
       react: await LawyerRecordsEmailTemplate({ lawFirm: formData.lawFirm, email: formData.email, phone: normalizedPhone, patientName: formData.patientName, dob: formData.dob, dos: formData.dos, records: formData.records, files: formData.files }),
       attachments: formData.files.map(file => ({

--- a/components/ui/BookAppointmentForm.tsx
+++ b/components/ui/BookAppointmentForm.tsx
@@ -52,18 +52,24 @@ const BookAppointmentForm = ({
     title = 'Book An Appointment',
     bgColor = 'bg-[#F2F6FC]',
     textColor = 'text-black',
+    initialFirstName = '',
+    initialLastName = '',
+    initialPhone = '',
 }: {
     title?: string;
     bgColor?: string;
     textColor?: string;
+    initialFirstName?: string;
+    initialLastName?: string;
+    initialPhone?: string;
 }) => {
     const form = useForm<FormData>({
         resolver: zodResolver(formSchema),
         defaultValues: {
-            firstName: '',
-            lastName: '',
+            firstName: initialFirstName,
+            lastName: initialLastName,
             email: '',
-            phone: '',
+            phone: initialPhone,
             postalCode: '',
             type: '',
             message: '',

--- a/components/ui/HomepageMobileHeroForm.tsx
+++ b/components/ui/HomepageMobileHeroForm.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Phone, User } from "lucide-react";
+import BookAppointmentForm from "@/components/ui/BookAppointmentForm";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  formatUSPhoneNumber,
+  hasAtMostTenPhoneDigits,
+} from "@/lib/validation/phone";
+
+type DataLayerEvent = Record<string, string | number | boolean | null | undefined>;
+
+function pushDataLayerEvent(event: DataLayerEvent) {
+  if (typeof window === "undefined") return;
+  window.dataLayer = window.dataLayer || [];
+  window.dataLayer.push(event);
+}
+
+export default function HomepageMobileHeroForm() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+
+  const openDialog = useCallback(() => {
+    pushDataLayerEvent({
+      event: "mobile_hero_form_open",
+      page_type: "home",
+      form_type: "appointment",
+      cta_text: "Request Appointment",
+      cta_position: "mobile_hero_top_fold",
+      page_path: window.location.pathname,
+    });
+    setIsDialogOpen(true);
+  }, []);
+
+  const handleCallClick = useCallback(() => {
+    pushDataLayerEvent({
+      event: "mobile_hero_call_click",
+      page_type: "home",
+      phone_number: "561-653-3177",
+      cta_text: "Call Now: 561-653-3177",
+      cta_position: "mobile_hero_top_fold",
+      page_path: window.location.pathname,
+    });
+  }, []);
+
+  // Split "First Last" into parts for pre-population
+  const nameParts = name.trim().split(/\s+/);
+  const initialFirstName = nameParts[0] ?? "";
+  const initialLastName = nameParts.slice(1).join(" ");
+
+  return (
+    <>
+      {/* ── Mobile / tablet hero panel (hidden at xl+ where sidebar form renders) ── */}
+      <div className="xl:hidden w-full space-y-3">
+
+        {/* Mini form card */}
+        <div className="bg-white rounded-2xl p-5 shadow-2xl">
+          <p className="text-gray-900 font-bold text-lg leading-tight mb-0.5">
+            Need to be seen today?
+          </p>
+          <p className="text-gray-500 text-sm mb-4">
+            Same-day appointments available — walk-ins welcome.
+          </p>
+
+          <div className="space-y-3 mb-4">
+            {/* Name */}
+            <div className="relative">
+              <User className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+              <input
+                type="text"
+                placeholder="Your Name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                autoComplete="name"
+                className="w-full h-12 pl-9 pr-3 rounded-xl border border-gray-200 bg-gray-50 text-gray-900 text-sm outline-none focus:border-[#2563eb] focus:ring-1 focus:ring-[#2563eb] transition"
+              />
+            </div>
+
+            {/* Phone */}
+            <div className="relative">
+              <Phone className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" />
+              <input
+                type="tel"
+                inputMode="tel"
+                placeholder="Phone Number"
+                value={phone}
+                onChange={(e) => {
+                  if (hasAtMostTenPhoneDigits(e.target.value)) {
+                    setPhone(formatUSPhoneNumber(e.target.value));
+                  }
+                }}
+                autoComplete="tel"
+                className="w-full h-12 pl-9 pr-3 rounded-xl border border-gray-200 bg-gray-50 text-gray-900 text-sm outline-none focus:border-[#2563eb] focus:ring-1 focus:ring-[#2563eb] transition"
+              />
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={openDialog}
+            className="w-full h-12 bg-[#D52128] hover:bg-[#b81b22] active:bg-[#9a1520] text-white font-bold text-base rounded-xl shadow-lg touch-manipulation transition-colors duration-200"
+          >
+            Request Appointment &rarr;
+          </button>
+
+          <p className="text-[11px] text-gray-400 text-center mt-2.5">
+            Same-day appointments &middot; Walk-ins welcome &middot; No obligation
+          </p>
+        </div>
+
+        {/* Call Now — below the card */}
+        <a
+          href="tel:5616533177"
+          onClick={handleCallClick}
+          className="flex items-center justify-center gap-3 w-full bg-[#2563eb] hover:bg-[#1d4ed8] active:bg-[#1e40af] text-white font-bold text-base rounded-xl shadow-lg touch-manipulation transition-colors duration-200"
+          style={{ minHeight: "52px" }}
+          aria-label="Call now: 561-653-3177"
+        >
+          <Phone className="w-5 h-5 flex-shrink-0" />
+          Call Now: 561-653-3177
+        </a>
+      </div>
+
+      {/* ── Desktop xl+: full sidebar form (unchanged) ── */}
+      <div className="hidden xl:block w-full h-full">
+        <BookAppointmentForm
+          title="Request an appointment"
+          bgColor="backdrop-blur-3xl lg:p-8 p-4 rounded-2xl"
+          textColor="text-white"
+        />
+      </div>
+
+      {/* ── Full appointment form dialog ── */}
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="max-h-[92dvh] overflow-y-auto w-full max-w-[calc(100%-1.5rem)] sm:max-w-lg p-0 gap-0">
+          <DialogHeader className="px-6 pt-6 pb-0">
+            <DialogTitle className="text-xl font-bold text-gray-900">
+              Request an Appointment
+            </DialogTitle>
+          </DialogHeader>
+          <div className="px-2 pb-6">
+            <BookAppointmentForm
+              title=""
+              bgColor="bg-transparent p-4"
+              textColor="text-gray-900"
+              initialFirstName={initialFirstName}
+              initialLastName={initialLastName}
+              initialPhone={phone}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
…cident pages

## What changed

### New components
- `components/ui/HomepageMobileHeroForm.tsx` (new, client component)
  - Mobile hero replacement for homepage (<xl breakpoint)
  - Shows a white mini form card with Name + Phone fields and a red "Request Appointment →" CTA
  - CTA opens a full Radix UI Dialog with the complete BookAppointmentForm
  - Name/phone from mini fields are pre-populated into the dialog form
  - Blue "Call Now: 561-653-3177" button renders BELOW the card
  - Desktop (xl+): renders the existing full sidebar BookAppointmentForm unchanged

- `components/accident/AccidentMobileFormReveal.tsx` (new, client component)
  - Mobile-only block (<md breakpoint) inserted into HeroWithForm left column
  - Same mini form card pattern: Name + Phone → red "Request Same-Day Exam →" → Radix Dialog
  - Dialog renders the CompactAccidentForm (existing form, existing submit logic)
  - Blue "Call Now: {phoneDisplay}" button below the card
  - Listens for `primaryuc:expand-accident-form` custom DOM event (fired by MobileStickyFooter)
  - dataLayer events: car_accident_mobile_hero_form_open, car_accident_mobile_hero_call_click

### Modified components

- `components/ui/BookAppointmentForm.tsx`
  - Added optional props: initialFirstName, initialLastName, initialPhone
  - These seed react-hook-form defaultValues so dialog pre-populates from mini form fields

- `components/accident/HeroWithForm.tsx`
  - subtitle and checklist are now `hidden md:block` / `hidden md:flex` — desktop only WHY: on mobile these 6+ lines pushed the form below the fold
  - Hero min-h removed on mobile (md:min-h-[85vh] instead of always-on)
  - Top padding reduced on mobile (pt-8 vs pt-20)
  - Server-rendered phone CTA is `hidden md:inline-flex` (mobile uses AccidentMobileFormReveal)
  - Right-column form card is `hidden md:flex` (mobile form lives inside AccidentMobileFormReveal dialog)
  - AccidentMobileFormReveal inserted in left column immediately after H1

- `components/accident/MobileStickyFooter.tsx`
  - "Request Exam" now dispatches `primaryuc:expand-accident-form` CustomEvent to open dialog
  - "Call Now" fires car_accident_sticky_footer_call_click dataLayer event
  - Scrolls to #accident-mobile-hero-form or #accident-appointment-form after dispatch

- `app/page.tsx`
  - Hero form div now renders <HomepageMobileHeroForm /> instead of <BookAppointmentForm /> directly

- `app/car-accident/[city]/page.tsx`
  - Removed MobileStickyFooter import and usage (sticky bar removed per design)

## Mobile UX result (all car accident pages)
  H1 → white mini form card (Name + Phone + red CTA) → blue Call Now button
  All content (subtitle, checklist, trust bullets) stays but scrolls below the fold on mobile
  Tapping CTA opens full-screen form dialog with all fields

## Desktop: no changes to layout or functionality

## Tracking (dataLayer, GTM-safe)
  mobile_hero_call_click          — homepage hero Call Now tap
  mobile_hero_form_open           — homepage hero Request Appointment tap
  car_accident_mobile_hero_call_click  — accident hero Call Now tap
  car_accident_mobile_hero_form_open   — accident hero Request Exam tap
  car_accident_sticky_footer_call_click — sticky footer Call Now tap